### PR TITLE
feat: add tag filters and insight notes

### DIFF
--- a/src/app/cabinet/[id]/edit/page.tsx
+++ b/src/app/cabinet/[id]/edit/page.tsx
@@ -134,8 +134,7 @@ export default function CabinetEditPage({ params }: CabinetEditPageProps) {
     }
     const trimmed = name.trim();
     if (!trimmed) {
-      setError("名稱不可為空");
-      setMessage(null);
+      setMessage("名稱不可為空");
       return;
     }
     setSaving(true);
@@ -146,15 +145,25 @@ export default function CabinetEditPage({ params }: CabinetEditPageProps) {
         name: trimmed,
         updatedAt: serverTimestamp(),
       });
-      setMessage("已更新櫃子名稱");
       setName(trimmed);
+      setMessage("已更新櫃子名稱");
     } catch (err) {
       console.error("更新櫃子名稱失敗", err);
-      setError("儲存櫃子資料時發生錯誤");
+      setMessage("儲存櫃子資料時發生錯誤");
     } finally {
       setSaving(false);
     }
   }
+
+  useEffect(() => {
+    if (!message) {
+      return;
+    }
+    if (typeof window !== "undefined") {
+      window.alert(message);
+    }
+    setMessage(null);
+  }, [message]);
 
   async function handleAddTag() {
     if (!user || !canEdit || tagSaving) {
@@ -402,12 +411,6 @@ export default function CabinetEditPage({ params }: CabinetEditPageProps) {
         {error && (
           <div className="rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">
             {error}
-          </div>
-        )}
-
-        {message && (
-          <div className="rounded-xl bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
-            {message}
           </div>
         )}
 

--- a/src/app/cabinet/[id]/page.tsx
+++ b/src/app/cabinet/[id]/page.tsx
@@ -736,10 +736,9 @@ export default function CabinetDetailPage({ params }: CabinetPageProps) {
               <button
                 type="button"
                 onClick={handleTagSubmit}
-                className={`${buttonClass({ variant: "secondary" })} w-full sm:w-auto text-center`}
+                className={`${buttonClass({ variant: "secondary" })} w-full whitespace-pre-line text-center sm:w-auto`}
               >
-                <span className="block leading-tight">加入</span>
-                <span className="block leading-tight">標籤</span>
+                {"加入\n標籤"}
               </button>
             </div>
             {availableTags.length > 0 && (

--- a/src/app/cabinet/[id]/page.tsx
+++ b/src/app/cabinet/[id]/page.tsx
@@ -736,9 +736,10 @@ export default function CabinetDetailPage({ params }: CabinetPageProps) {
               <button
                 type="button"
                 onClick={handleTagSubmit}
-                className={`${buttonClass({ variant: "secondary" })} w-full sm:w-auto`}
+                className={`${buttonClass({ variant: "secondary" })} w-full sm:w-auto text-center`}
               >
-                加入標籤
+                <span className="block leading-tight">加入</span>
+                <span className="block leading-tight">標籤</span>
               </button>
             </div>
             {availableTags.length > 0 && (

--- a/src/app/cabinet/[id]/page.tsx
+++ b/src/app/cabinet/[id]/page.tsx
@@ -736,7 +736,7 @@ export default function CabinetDetailPage({ params }: CabinetPageProps) {
               <button
                 type="button"
                 onClick={handleTagSubmit}
-                className={`${buttonClass({ variant: "secondary" })} w-full whitespace-pre-line text-center sm:w-auto`}
+                className={`${buttonClass({ variant: "secondary" })} h-auto min-h-[2.5rem] w-full flex-col whitespace-pre-line text-center leading-tight sm:w-auto`}
               >
                 {"加入\n標籤"}
               </button>

--- a/src/app/cabinets/page.tsx
+++ b/src/app/cabinets/page.tsx
@@ -90,6 +90,7 @@ export default function CabinetsPage() {
         name: trimmed,
         createdAt: serverTimestamp(),
         updatedAt: serverTimestamp(),
+        tags: [],
       });
       setName("");
       setFeedback({ type: "success", message: "已新增櫃子" });

--- a/src/app/item/[id]/page.tsx
+++ b/src/app/item/[id]/page.tsx
@@ -402,6 +402,9 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
   const links = item.links ?? [];
   const insightNote = item.insightNote ?? "";
   const hasInsightNote = insightNote.trim().length > 0;
+  const tagLinkBase = item.cabinetId
+    ? `/cabinet/${encodeURIComponent(item.cabinetId)}`
+    : null;
 
   return (
     <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
@@ -520,14 +523,28 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
                 <div className="space-y-2">
                   <div className="text-sm text-gray-500">標籤</div>
                   <div className="flex flex-wrap gap-2">
-                    {tags.map((tag) => (
-                      <span
-                        key={tag}
-                        className="rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-700"
-                      >
-                        #{tag}
-                      </span>
-                    ))}
+                    {tags.map((tag) => {
+                      if (!tagLinkBase) {
+                        return (
+                          <span
+                            key={tag}
+                            className="rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-700"
+                          >
+                            #{tag}
+                          </span>
+                        );
+                      }
+                      const href = `${tagLinkBase}?tag=${encodeURIComponent(tag)}`;
+                      return (
+                        <Link
+                          key={tag}
+                          href={href}
+                          className="rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-700 transition hover:bg-blue-50 hover:text-blue-700"
+                        >
+                          #{tag}
+                        </Link>
+                      );
+                    })}
                   </div>
                 </div>
               )}
@@ -603,9 +620,6 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
         <section className="space-y-4 rounded-2xl border bg-white/70 p-6 shadow-sm">
           <div className="space-y-2">
             <h2 className="text-xl font-semibold text-gray-900">心得 / 筆記</h2>
-            <p className="text-sm text-gray-600">
-              這裡記錄的是屬於自己的觀後感、想法或推薦理由，僅供參考。
-            </p>
           </div>
           {hasInsightNote ? (
             <div className="whitespace-pre-wrap break-words rounded-xl bg-white px-4 py-3 text-sm text-gray-800 shadow-inner">

--- a/src/app/item/[id]/page.tsx
+++ b/src/app/item/[id]/page.tsx
@@ -182,6 +182,43 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
               return normalized;
             })()
           : [];
+        const appearances = Array.isArray(data.appearances)
+          ? data.appearances
+              .map((entry) => {
+                if (!entry || typeof entry !== "object") {
+                  return null;
+                }
+                const recordEntry = entry as {
+                  name?: unknown;
+                  thumbUrl?: unknown;
+                  note?: unknown;
+                };
+                const name =
+                  typeof recordEntry.name === "string"
+                    ? recordEntry.name.trim()
+                    : "";
+                if (!name) {
+                  return null;
+                }
+                const thumbUrl =
+                  typeof recordEntry.thumbUrl === "string"
+                    ? recordEntry.thumbUrl.trim()
+                    : "";
+                const note =
+                  typeof recordEntry.note === "string"
+                    ? recordEntry.note.trim()
+                    : "";
+                return {
+                  name,
+                  thumbUrl: thumbUrl || null,
+                  note: note || null,
+                };
+              })
+              .filter(
+                (entry): entry is { name: string; thumbUrl?: string | null; note?: string | null } =>
+                  Boolean(entry)
+              )
+          : [];
         const record: ItemRecord = {
           id: snap.id,
           uid: typeof data.uid === "string" ? data.uid : user.uid,
@@ -196,6 +233,7 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
           progressNote: typeof data.progressNote === "string" ? data.progressNote : null,
           insightNote: typeof data.insightNote === "string" ? data.insightNote : null,
           note: typeof data.note === "string" ? data.note : null,
+          appearances,
           rating: ratingValue,
           status: statusValue,
           updateFrequency: updateFrequencyValue,
@@ -400,8 +438,10 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
   const updatedAtText = formatDateTime(item.updatedAt);
   const tags = item.tags ?? [];
   const links = item.links ?? [];
+  const appearances = item.appearances ?? [];
   const insightNote = item.insightNote ?? "";
   const hasInsightNote = insightNote.trim().length > 0;
+  const hasAppearances = appearances.length > 0;
   const tagLinkBase = item.cabinetId
     ? `/cabinet/${encodeURIComponent(item.cabinetId)}`
     : null;
@@ -616,6 +656,43 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
             </div>
           )}
         </section>
+
+        {hasAppearances && (
+          <section className="space-y-4 rounded-2xl border bg-white/70 p-6 shadow-sm">
+            <div className="space-y-2">
+              <h2 className="text-xl font-semibold text-gray-900">登場列表</h2>
+              <p className="text-sm text-gray-500">依編輯順序列出重要角色、地點或其他物件。</p>
+            </div>
+            <div className="space-y-4">
+              {appearances.map((entry, index) => (
+                <div
+                  key={`${entry.name}-${index}`}
+                  className="flex gap-4 rounded-2xl border bg-white/80 p-4 shadow-sm"
+                >
+                  {entry.thumbUrl ? (
+                    <div className="relative aspect-square w-20 shrink-0 overflow-hidden rounded-lg border bg-white">
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={entry.thumbUrl}
+                        alt={`${entry.name} 縮圖`}
+                        className="h-full w-full object-cover"
+                        loading="lazy"
+                      />
+                    </div>
+                  ) : null}
+                  <div className="flex-1 space-y-2">
+                    <div className="text-base font-medium text-gray-900">{entry.name}</div>
+                    {entry.note && (
+                      <div className="whitespace-pre-wrap break-words text-sm text-gray-700">
+                        {entry.note}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
 
         <section className="space-y-4 rounded-2xl border bg-white/70 p-6 shadow-sm">
           <div className="space-y-2">

--- a/src/app/item/[id]/page.tsx
+++ b/src/app/item/[id]/page.tsx
@@ -400,7 +400,8 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
   const updatedAtText = formatDateTime(item.updatedAt);
   const tags = item.tags ?? [];
   const links = item.links ?? [];
-  const insightNote = item.insightNote ?? null;
+  const insightNote = item.insightNote ?? "";
+  const hasInsightNote = insightNote.trim().length > 0;
 
   return (
     <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
@@ -549,7 +550,7 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
                           {link.label}
                         </a>
                         {link.isPrimary && (
-                          <span className="text-xs text-emerald-600">（此為&quot;點我觀看&quot;觸發連結）</span>
+                          <span className="text-xs text-emerald-600">{`（此為"點我觀看"觸發連結）`}</span>
                         )}
                       </li>
                     ))}
@@ -599,19 +600,23 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
           )}
         </section>
 
-        {insightNote && (
-          <section className="space-y-4 rounded-2xl border bg-white/70 p-6 shadow-sm">
-            <div className="space-y-2">
-              <h2 className="text-xl font-semibold text-gray-900">心得 / 筆記</h2>
-              <p className="text-sm text-gray-600">
-                這裡記錄的是屬於自己的觀後感、想法或推薦理由，僅供參考。
-              </p>
-            </div>
-            <div className="rounded-xl bg-white px-4 py-3 text-sm text-gray-800 shadow-inner whitespace-pre-wrap break-words">
+        <section className="space-y-4 rounded-2xl border bg-white/70 p-6 shadow-sm">
+          <div className="space-y-2">
+            <h2 className="text-xl font-semibold text-gray-900">心得 / 筆記</h2>
+            <p className="text-sm text-gray-600">
+              這裡記錄的是屬於自己的觀後感、想法或推薦理由，僅供參考。
+            </p>
+          </div>
+          {hasInsightNote ? (
+            <div className="whitespace-pre-wrap break-words rounded-xl bg-white px-4 py-3 text-sm text-gray-800 shadow-inner">
               {insightNote}
             </div>
-          </section>
-        )}
+          ) : (
+            <p className="rounded-xl border border-dashed border-gray-200 bg-white px-4 py-6 text-center text-sm text-gray-400">
+              目前尚未填寫心得 / 筆記。
+            </p>
+          )}
+        </section>
       </div>
     </main>
   );

--- a/src/app/item/[id]/page.tsx
+++ b/src/app/item/[id]/page.tsx
@@ -194,6 +194,7 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
           links,
           thumbUrl: typeof data.thumbUrl === "string" ? data.thumbUrl : null,
           progressNote: typeof data.progressNote === "string" ? data.progressNote : null,
+          insightNote: typeof data.insightNote === "string" ? data.insightNote : null,
           note: typeof data.note === "string" ? data.note : null,
           rating: ratingValue,
           status: statusValue,
@@ -399,6 +400,7 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
   const updatedAtText = formatDateTime(item.updatedAt);
   const tags = item.tags ?? [];
   const links = item.links ?? [];
+  const insightNote = item.insightNote ?? null;
 
   return (
     <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
@@ -529,11 +531,11 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
                 </div>
               )}
 
-              {links.length > 0 && (
-                <div className="space-y-2">
-                  <div className="text-sm text-gray-500">來源連結</div>
-                  <ul className="space-y-2 text-sm">
-                    {links.map((link) => (
+          {links.length > 0 && (
+            <div className="space-y-2">
+              <div className="text-sm text-gray-500">來源連結</div>
+              <ul className="space-y-2 text-sm">
+                {links.map((link) => (
                       <li
                         key={`${link.label}-${link.url}`}
                         className="flex flex-wrap items-center gap-2"
@@ -547,28 +549,28 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
                           {link.label}
                         </a>
                         {link.isPrimary && (
-                          <span className="text-xs text-emerald-600">（點我觀看）</span>
+                          <span className="text-xs text-emerald-600">（此為&quot;點我觀看&quot;觸發連結）</span>
                         )}
                       </li>
                     ))}
-                  </ul>
-                </div>
-              )}
+              </ul>
+            </div>
+          )}
 
-              {item.progressNote && (
-                <div className="space-y-1">
-                  <div className="text-sm text-gray-500">進度備註</div>
-                  <div className="rounded-xl bg-blue-50 px-4 py-3 text-sm text-blue-800">
-                    {item.progressNote}
-                  </div>
-                </div>
-              )}
+          {item.progressNote && (
+            <div className="space-y-1">
+              <div className="text-sm text-gray-500">進度備註</div>
+              <div className="rounded-xl bg-blue-50 px-4 py-3 text-sm text-blue-800">
+                {item.progressNote}
+              </div>
+            </div>
+          )}
 
-              {item.note && (
-                <div className="space-y-1">
-                  <div className="text-sm text-gray-500">一般備註</div>
-                  <div className="rounded-xl bg-gray-100 px-4 py-3 text-sm text-gray-700">
-                    {item.note}
+          {item.note && (
+            <div className="space-y-1">
+              <div className="text-sm text-gray-500">一般備註</div>
+              <div className="rounded-xl bg-gray-100 px-4 py-3 text-sm text-gray-700">
+                {item.note}
                   </div>
                 </div>
               )}
@@ -596,6 +598,20 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
             </div>
           )}
         </section>
+
+        {insightNote && (
+          <section className="space-y-4 rounded-2xl border bg-white/70 p-6 shadow-sm">
+            <div className="space-y-2">
+              <h2 className="text-xl font-semibold text-gray-900">心得 / 筆記</h2>
+              <p className="text-sm text-gray-600">
+                這裡記錄的是屬於自己的觀後感、想法或推薦理由，僅供參考。
+              </p>
+            </div>
+            <div className="rounded-xl bg-white px-4 py-3 text-sm text-gray-800 shadow-inner whitespace-pre-wrap break-words">
+              {insightNote}
+            </div>
+          </section>
+        )}
       </div>
     </main>
   );

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -104,7 +104,7 @@ export default function ItemCard({ item }: ItemCardProps) {
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
         <Link
           href={detailHref}
-          className="relative h-20 w-16 shrink-0 overflow-hidden rounded-xl border border-gray-200 bg-gray-100 shadow-inner"
+          className="relative h-24 w-20 shrink-0 overflow-hidden rounded-xl border border-gray-200 bg-gray-100 shadow-inner"
         >
           {item.thumbUrl ? (
             canUseOptimizedThumb ? (
@@ -112,7 +112,7 @@ export default function ItemCard({ item }: ItemCardProps) {
                 src={item.thumbUrl}
                 alt={`${item.titleZh} 縮圖`}
                 fill
-                sizes="64px"
+                sizes="80px"
                 className="object-cover"
               />
             ) : (
@@ -131,8 +131,11 @@ export default function ItemCard({ item }: ItemCardProps) {
           )}
         </Link>
 
-        <div className="flex w-full flex-col items-stretch gap-2 sm:w-48">
-          <Link href={detailHref} className={buttonClass({ variant: "secondary" })}>
+        <div className="flex w-full flex-col gap-2 sm:ml-auto sm:w-auto sm:items-end">
+          <Link
+            href={detailHref}
+            className={`${buttonClass({ variant: "secondary" })} w-full sm:w-auto`}
+          >
             查看詳細頁面
           </Link>
           {primaryLink ? (
@@ -140,7 +143,7 @@ export default function ItemCard({ item }: ItemCardProps) {
               href={primaryLink.url}
               target="_blank"
               rel="noopener noreferrer"
-              className={buttonClass({ variant: "secondary" })}
+              className={`${buttonClass({ variant: "secondary" })} w-full sm:w-auto`}
             >
               點我觀看
             </a>
@@ -148,7 +151,7 @@ export default function ItemCard({ item }: ItemCardProps) {
             <button
               type="button"
               disabled
-              className={`${buttonClass({ variant: "secondary" })} border-dashed text-gray-400`}
+              className={`${buttonClass({ variant: "secondary" })} w-full border-dashed text-gray-400 sm:w-auto`}
             >
               尚未提供連結
             </button>

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -80,6 +80,7 @@ export default function ItemCard({ item }: ItemCardProps) {
     ? updateFrequencyLabelMap.get(item.updateFrequency) ?? item.updateFrequency
     : "未設定";
   const canUseOptimizedThumb = isOptimizedImageUrl(item.thumbUrl);
+  const detailHref = `/item/${item.id}`;
 
   return (
     <article className="space-y-6 rounded-3xl border border-gray-100 bg-white/90 p-6 shadow-sm">
@@ -102,7 +103,10 @@ export default function ItemCard({ item }: ItemCardProps) {
 
       <div className="flex flex-col gap-4 md:flex-row md:items-start">
         <div className="flex flex-1 gap-4">
-          <div className="relative h-20 w-16 shrink-0 overflow-hidden rounded-xl border border-gray-200 bg-gray-100 shadow-inner">
+          <Link
+            href={detailHref}
+            className="relative h-20 w-16 shrink-0 overflow-hidden rounded-xl border border-gray-200 bg-gray-100 shadow-inner"
+          >
             {item.thumbUrl ? (
               canUseOptimizedThumb ? (
                 <Image
@@ -126,7 +130,7 @@ export default function ItemCard({ item }: ItemCardProps) {
                 無封面
               </div>
             )}
-          </div>
+          </Link>
 
           <div className="flex flex-1 flex-col gap-3">
             <div className="grid gap-3 text-sm sm:grid-cols-2">
@@ -151,14 +155,40 @@ export default function ItemCard({ item }: ItemCardProps) {
                 <span className="block font-medium text-gray-900">{authorDisplay}</span>
               </div>
             </div>
+
+            {tags.length > 0 && (
+              <div className="flex flex-wrap gap-2 text-xs text-gray-600">
+                {tags.map((tag) => {
+                  if (!item.cabinetId) {
+                    return (
+                      <span
+                        key={tag}
+                        className="rounded-full border border-gray-200 bg-gray-100 px-3 py-1"
+                      >
+                        #{tag}
+                      </span>
+                    );
+                  }
+                  const tagHref = `/cabinet/${encodeURIComponent(
+                    item.cabinetId
+                  )}?tag=${encodeURIComponent(tag)}`;
+                  return (
+                    <Link
+                      key={tag}
+                      href={tagHref}
+                      className="rounded-full border border-gray-200 bg-white px-3 py-1 transition hover:border-blue-400 hover:bg-blue-50 hover:text-blue-700"
+                    >
+                      #{tag}
+                    </Link>
+                  );
+                })}
+              </div>
+            )}
           </div>
         </div>
 
         <div className="flex w-full flex-col items-stretch gap-2 md:w-48">
-          <Link
-            href={`/item/${item.id}`}
-            className={buttonClass({ variant: "secondary" })}
-          >
+          <Link href={detailHref} className={buttonClass({ variant: "secondary" })}>
             查看詳細頁面
           </Link>
           {primaryLink ? (
@@ -181,38 +211,6 @@ export default function ItemCard({ item }: ItemCardProps) {
           )}
         </div>
       </div>
-
-      {tags.length > 0 && (
-        <div className="space-y-2 rounded-2xl border border-gray-100 bg-gray-50 p-4">
-          <span className="text-xs font-medium text-gray-500">標籤</span>
-          <div className="flex flex-wrap gap-2 text-xs text-gray-600">
-            {tags.map((tag) => {
-              if (!item.cabinetId) {
-                return (
-                  <span
-                    key={tag}
-                    className="rounded-full border border-gray-200 bg-white px-3 py-1"
-                  >
-                    #{tag}
-                  </span>
-                );
-              }
-              const tagHref = `/cabinet/${encodeURIComponent(
-                item.cabinetId
-              )}?tag=${encodeURIComponent(tag)}`;
-              return (
-                <Link
-                  key={tag}
-                  href={tagHref}
-                  className="rounded-full border border-gray-200 bg-white px-3 py-1 transition hover:border-blue-400 hover:bg-blue-50 hover:text-blue-700"
-                >
-                  #{tag}
-                </Link>
-              );
-            })}
-          </div>
-        </div>
-      )}
 
       <div className="space-y-2 rounded-2xl border border-gray-100 bg-gray-50 px-4 py-3">
         <div className="text-sm font-medium text-gray-900">主進度</div>

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -291,11 +291,11 @@ export default function ItemCard({ item }: ItemCardProps) {
             {tags.length > 0 && (
               <div className="space-y-2 rounded-2xl border border-gray-100 bg-gray-50 p-4">
                 <span className="text-xs font-medium text-gray-500">標籤</span>
-                <div className="grid grid-cols-2 gap-2 text-xs text-gray-600 sm:grid-cols-3 lg:grid-cols-5">
+                <div className="flex flex-wrap gap-2 text-xs text-gray-600">
                   {tags.map((tag) => (
                     <span
                       key={tag}
-                      className="flex items-center justify-center rounded-full border border-gray-200 bg-white px-3 py-1"
+                      className="rounded-full border border-gray-200 bg-white px-3 py-1"
                     >
                       #{tag}
                     </span>

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -323,14 +323,30 @@ export default function ItemCard({ item }: ItemCardProps) {
         <div className="space-y-2 rounded-2xl border border-gray-100 bg-gray-50 p-4">
           <span className="text-xs font-medium text-gray-500">標籤</span>
           <div className="flex flex-wrap gap-2 text-xs text-gray-600">
-            {tags.map((tag) => (
-              <span
-                key={tag}
-                className="rounded-full border border-gray-200 bg-white px-3 py-1"
-              >
-                #{tag}
-              </span>
-            ))}
+            {tags.map((tag) => {
+              if (!item.cabinetId) {
+                return (
+                  <span
+                    key={tag}
+                    className="rounded-full border border-gray-200 bg-white px-3 py-1"
+                  >
+                    #{tag}
+                  </span>
+                );
+              }
+              const tagHref = `/cabinet/${encodeURIComponent(
+                item.cabinetId
+              )}?tag=${encodeURIComponent(tag)}`;
+              return (
+                <Link
+                  key={tag}
+                  href={tagHref}
+                  className="rounded-full border border-gray-200 bg-white px-3 py-1 transition hover:border-blue-400 hover:bg-blue-50 hover:text-blue-700"
+                >
+                  #{tag}
+                </Link>
+              );
+            })}
           </div>
         </div>
       )}

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -132,56 +132,59 @@ export default function ItemCard({ item }: ItemCardProps) {
             )}
           </Link>
 
-          <div className="flex flex-1 flex-col gap-3">
-            <div className="grid gap-3 text-sm sm:grid-cols-2">
-              <div className="space-y-1">
+          <div className="flex flex-1 flex-col gap-4">
+            <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm text-gray-900">
+              <div className="flex items-center gap-2">
                 <span className="text-xs text-gray-500">狀態</span>
-                <span className="block font-medium text-gray-900">{statusLabel}</span>
+                <span className="font-medium text-gray-900">{statusLabel}</span>
               </div>
-              <div className="space-y-1">
+              <div className="flex items-center gap-2">
                 <span className="text-xs text-gray-500">更新頻率</span>
-                <span className="block font-medium text-gray-900">{updateFrequencyLabel}</span>
+                <span className="font-medium text-gray-900">{updateFrequencyLabel}</span>
               </div>
-              <div className="space-y-1">
+              <div className="flex items-center gap-2">
                 <span className="text-xs text-gray-500">下次更新</span>
-                <span className="block font-medium text-gray-900">{nextUpdateText}</span>
+                <span className="font-medium text-gray-900">{nextUpdateText}</span>
               </div>
-              <div className="space-y-1">
+              <div className="flex items-center gap-2">
                 <span className="text-xs text-gray-500">評分</span>
-                <span className="block font-medium text-gray-900">{ratingDisplay}</span>
+                <span className="font-medium text-gray-900">{ratingDisplay}</span>
               </div>
-              <div className="space-y-1 sm:col-span-2">
+              <div className="flex items-center gap-2 basis-full text-sm text-gray-900">
                 <span className="text-xs text-gray-500">作者 / 製作</span>
-                <span className="block font-medium text-gray-900">{authorDisplay}</span>
+                <span className="font-medium text-gray-900">{authorDisplay}</span>
               </div>
             </div>
 
             {tags.length > 0 && (
-              <div className="flex flex-wrap gap-2 text-xs text-gray-600">
-                {tags.map((tag) => {
-                  if (!item.cabinetId) {
+              <div className="flex flex-wrap items-center gap-2 text-xs text-gray-600">
+                <span className="text-xs text-gray-500">標籤</span>
+                <div className="flex flex-wrap gap-2">
+                  {tags.map((tag) => {
+                    if (!item.cabinetId) {
+                      return (
+                        <span
+                          key={tag}
+                          className="rounded-full border border-gray-200 bg-gray-100 px-3 py-1"
+                        >
+                          #{tag}
+                        </span>
+                      );
+                    }
+                    const tagHref = `/cabinet/${encodeURIComponent(
+                      item.cabinetId
+                    )}?tag=${encodeURIComponent(tag)}`;
                     return (
-                      <span
+                      <Link
                         key={tag}
-                        className="rounded-full border border-gray-200 bg-gray-100 px-3 py-1"
+                        href={tagHref}
+                        className="rounded-full border border-gray-200 bg-white px-3 py-1 transition hover:border-blue-400 hover:bg-blue-50 hover:text-blue-700"
                       >
                         #{tag}
-                      </span>
+                      </Link>
                     );
-                  }
-                  const tagHref = `/cabinet/${encodeURIComponent(
-                    item.cabinetId
-                  )}?tag=${encodeURIComponent(tag)}`;
-                  return (
-                    <Link
-                      key={tag}
-                      href={tagHref}
-                      className="rounded-full border border-gray-200 bg-white px-3 py-1 transition hover:border-blue-400 hover:bg-blue-50 hover:text-blue-700"
-                    >
-                      #{tag}
-                    </Link>
-                  );
-                })}
+                  })}
+                </div>
               </div>
             )}
           </div>

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -288,22 +288,6 @@ export default function ItemCard({ item }: ItemCardProps) {
               </div>
             </div>
 
-            {tags.length > 0 && (
-              <div className="space-y-2 rounded-2xl border border-gray-100 bg-gray-50 p-4">
-                <span className="text-xs font-medium text-gray-500">標籤</span>
-                <div className="flex flex-wrap gap-2 text-xs text-gray-600">
-                  {tags.map((tag) => (
-                    <span
-                      key={tag}
-                      className="rounded-full border border-gray-200 bg-white px-3 py-1"
-                    >
-                      #{tag}
-                    </span>
-                  ))}
-                </div>
-              </div>
-            )}
-
           </div>
         </div>
 
@@ -334,6 +318,22 @@ export default function ItemCard({ item }: ItemCardProps) {
           )}
         </div>
       </div>
+
+      {tags.length > 0 && (
+        <div className="space-y-2 rounded-2xl border border-gray-100 bg-gray-50 p-4">
+          <span className="text-xs font-medium text-gray-500">標籤</span>
+          <div className="flex flex-wrap gap-2 text-xs text-gray-600">
+            {tags.map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full border border-gray-200 bg-white px-3 py-1"
+              >
+                #{tag}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
 
       <div className="space-y-2 rounded-2xl border border-gray-100 bg-gray-50 px-4 py-3">
         <div className="text-sm font-medium text-gray-900">主進度</div>

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -101,96 +101,37 @@ export default function ItemCard({ item }: ItemCardProps) {
         </button>
       </div>
 
-      <div className="flex flex-col gap-4 md:flex-row md:items-start">
-        <div className="flex flex-1 gap-4">
-          <Link
-            href={detailHref}
-            className="relative h-20 w-16 shrink-0 overflow-hidden rounded-xl border border-gray-200 bg-gray-100 shadow-inner"
-          >
-            {item.thumbUrl ? (
-              canUseOptimizedThumb ? (
-                <Image
-                  src={item.thumbUrl}
-                  alt={`${item.titleZh} 縮圖`}
-                  fill
-                  sizes="64px"
-                  className="object-cover"
-                />
-              ) : (
-                /* eslint-disable-next-line @next/next/no-img-element */
-                <img
-                  src={item.thumbUrl}
-                  alt={`${item.titleZh} 縮圖`}
-                  className="h-full w-full object-cover"
-                  loading="lazy"
-                />
-              )
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
+        <Link
+          href={detailHref}
+          className="relative h-20 w-16 shrink-0 overflow-hidden rounded-xl border border-gray-200 bg-gray-100 shadow-inner"
+        >
+          {item.thumbUrl ? (
+            canUseOptimizedThumb ? (
+              <Image
+                src={item.thumbUrl}
+                alt={`${item.titleZh} 縮圖`}
+                fill
+                sizes="64px"
+                className="object-cover"
+              />
             ) : (
-              <div className="flex h-full w-full items-center justify-center text-[10px] font-medium text-gray-400">
-                無封面
-              </div>
-            )}
-          </Link>
-
-          <div className="flex flex-1 flex-col gap-4">
-            <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm text-gray-900">
-              <div className="flex items-center gap-2">
-                <span className="text-xs text-gray-500">狀態</span>
-                <span className="font-medium text-gray-900">{statusLabel}</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <span className="text-xs text-gray-500">更新頻率</span>
-                <span className="font-medium text-gray-900">{updateFrequencyLabel}</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <span className="text-xs text-gray-500">下次更新</span>
-                <span className="font-medium text-gray-900">{nextUpdateText}</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <span className="text-xs text-gray-500">評分</span>
-                <span className="font-medium text-gray-900">{ratingDisplay}</span>
-              </div>
-              <div className="flex items-center gap-2 basis-full text-sm text-gray-900">
-                <span className="text-xs text-gray-500">作者 / 製作</span>
-                <span className="font-medium text-gray-900">{authorDisplay}</span>
-              </div>
+              /* eslint-disable-next-line @next/next/no-img-element */
+              <img
+                src={item.thumbUrl}
+                alt={`${item.titleZh} 縮圖`}
+                className="h-full w-full object-cover"
+                loading="lazy"
+              />
+            )
+          ) : (
+            <div className="flex h-full w-full items-center justify-center text-[10px] font-medium text-gray-400">
+              無封面
             </div>
+          )}
+        </Link>
 
-            {tags.length > 0 && (
-              <div className="flex flex-wrap items-center gap-2 text-xs text-gray-600">
-                <span className="text-xs text-gray-500">標籤</span>
-                <div className="flex flex-wrap gap-2">
-                  {tags.map((tag) => {
-                    if (!item.cabinetId) {
-                      return (
-                        <span
-                          key={tag}
-                          className="rounded-full border border-gray-200 bg-gray-100 px-3 py-1"
-                        >
-                          #{tag}
-                        </span>
-                      );
-                    }
-                    const tagHref = `/cabinet/${encodeURIComponent(
-                      item.cabinetId
-                    )}?tag=${encodeURIComponent(tag)}`;
-                    return (
-                      <Link
-                        key={tag}
-                        href={tagHref}
-                        className="rounded-full border border-gray-200 bg-white px-3 py-1 transition hover:border-blue-400 hover:bg-blue-50 hover:text-blue-700"
-                      >
-                        #{tag}
-                      </Link>
-                    );
-                  })}
-                </div>
-              </div>
-            )}
-          </div>
-        </div>
-
-        <div className="flex w-full flex-col items-stretch gap-2 md:w-48">
+        <div className="flex w-full flex-col items-stretch gap-2 sm:w-48">
           <Link href={detailHref} className={buttonClass({ variant: "secondary" })}>
             查看詳細頁面
           </Link>
@@ -214,6 +155,65 @@ export default function ItemCard({ item }: ItemCardProps) {
           )}
         </div>
       </div>
+
+      <div className="rounded-2xl border border-gray-100 bg-gray-50 p-4">
+        <div className="space-y-3 text-sm text-gray-900">
+          <div className="grid grid-cols-2 gap-x-6 text-xs text-gray-500">
+            <span>狀態</span>
+            <span>更新頻率</span>
+          </div>
+          <div className="grid grid-cols-2 gap-x-6 font-medium text-gray-900">
+            <span>{statusLabel}</span>
+            <span>{updateFrequencyLabel}</span>
+          </div>
+          <div className="grid grid-cols-2 gap-x-6 text-xs text-gray-500">
+            <span>下次更新</span>
+            <span>評分</span>
+          </div>
+          <div className="grid grid-cols-2 gap-x-6 font-medium text-gray-900">
+            <span>{nextUpdateText}</span>
+            <span>{ratingDisplay}</span>
+          </div>
+          <div className="space-y-1">
+            <div className="text-xs text-gray-500">作者 / 製作</div>
+            <div className="font-medium text-gray-900">{authorDisplay}</div>
+          </div>
+        </div>
+      </div>
+
+      {tags.length > 0 && (
+        <div className="rounded-2xl border border-gray-100 bg-white/80 p-4">
+          <div className="flex flex-wrap items-center gap-2 text-xs text-gray-600">
+            <span className="text-xs text-gray-500">標籤</span>
+            <div className="flex flex-wrap gap-2">
+              {tags.map((tag) => {
+                if (!item.cabinetId) {
+                  return (
+                    <span
+                      key={tag}
+                      className="rounded-full border border-gray-200 bg-gray-100 px-3 py-1"
+                    >
+                      #{tag}
+                    </span>
+                  );
+                }
+                const tagHref = `/cabinet/${encodeURIComponent(
+                  item.cabinetId
+                )}?tag=${encodeURIComponent(tag)}`;
+                return (
+                  <Link
+                    key={tag}
+                    href={tagHref}
+                    className="rounded-full border border-gray-200 bg-white px-3 py-1 transition hover:border-blue-400 hover:bg-blue-50 hover:text-blue-700"
+                  >
+                    #{tag}
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      )}
 
       <div className="space-y-2 rounded-2xl border border-gray-100 bg-gray-50 px-4 py-3">
         <div className="text-sm font-medium text-gray-900">主進度</div>

--- a/src/components/ItemForm.tsx
+++ b/src/components/ItemForm.tsx
@@ -705,19 +705,6 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
                   placeholder="例如：更新到最新話"
                 />
               </div>
-
-              <div className="space-y-1">
-                <label className="text-base">心得 / 筆記</label>
-                <textarea
-                  value={form.insightNote}
-                  onChange={(e) =>
-                    setForm((prev) => ({ ...prev, insightNote: e.target.value }))
-                  }
-                  className={textAreaClass}
-                  placeholder="分享一些觀後感、推薦理由等"
-                />
-              </div>
-
               <div className="space-y-1">
                 <label className="text-base">一般備註</label>
                 <textarea
@@ -727,6 +714,21 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
                   }
                   className={textAreaClass}
                   placeholder="自由填寫"
+                />
+              </div>
+            </section>
+
+            <section className={sectionClass}>
+              <div className="space-y-1">
+                <label className="text-base">心得 / 筆記</label>
+                <textarea
+                  value={form.insightNote}
+                  onChange={(e) =>
+                    setForm((prev) => ({ ...prev, insightNote: e.target.value }))
+                  }
+                  className={textAreaClass}
+                  placeholder="分享一些觀後感、推薦理由等"
+                  rows={6}
                 />
               </div>
             </section>

--- a/src/components/ItemForm.tsx
+++ b/src/components/ItemForm.tsx
@@ -62,6 +62,7 @@ type ItemFormState = {
   author: string;
   tagsText: string;
   progressNote: string;
+  insightNote: string;
   note: string;
   rating: string;
   status: ItemStatus;
@@ -83,6 +84,7 @@ function createDefaultState(initialCabinetId?: string): ItemFormState {
     author: "",
     tagsText: "",
     progressNote: "",
+    insightNote: "",
     note: "",
     rating: "",
     status: "planning",
@@ -201,6 +203,7 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
             ? data.tags.map((tag: unknown) => String(tag ?? "")).join("\n")
             : "",
           progressNote: (data.progressNote as string) ?? "",
+          insightNote: (data.insightNote as string) ?? "",
           note: (data.note as string) ?? "",
           rating: ratingValue,
           status,
@@ -346,6 +349,7 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
         links: filteredLinks,
         thumbUrl: form.thumbUrl,
         progressNote: form.progressNote,
+        insightNote: form.insightNote,
         note: form.note,
         rating: form.rating ? Number(form.rating) : undefined,
         status: form.status,
@@ -363,6 +367,7 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
         links: parsedData.links,
         thumbUrl: parsedData.thumbUrl ?? null,
         progressNote: parsedData.progressNote ?? null,
+        insightNote: parsedData.insightNote ?? null,
         note: parsedData.note ?? null,
         rating:
           parsedData.rating !== undefined ? parsedData.rating : null,
@@ -394,6 +399,7 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
         author: parsedData.author ?? "",
         tagsText: parsedData.tags.join("\n"),
         progressNote: parsedData.progressNote ?? "",
+        insightNote: parsedData.insightNote ?? "",
         note: parsedData.note ?? "",
         rating:
           parsedData.rating !== undefined
@@ -697,6 +703,18 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
                   }
                   className={textAreaClass}
                   placeholder="例如：更新到最新話"
+                />
+              </div>
+
+              <div className="space-y-1">
+                <label className="text-base">心得 / 筆記</label>
+                <textarea
+                  value={form.insightNote}
+                  onChange={(e) =>
+                    setForm((prev) => ({ ...prev, insightNote: e.target.value }))
+                  }
+                  className={textAreaClass}
+                  placeholder="分享一些觀後感、推薦理由等"
                 />
               </div>
 

--- a/src/components/ItemForm.tsx
+++ b/src/components/ItemForm.tsx
@@ -706,9 +706,14 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
     }
     setDeleting(true);
     setDeleteError(null);
+    const destinationCabinetId = form.cabinetId || initialCabinetId || "";
     try {
       await deleteItemWithProgress(itemId, user.uid);
-      router.replace("/cabinets");
+      if (destinationCabinetId) {
+        router.replace(`/cabinet/${destinationCabinetId}`);
+      } else {
+        router.replace("/cabinets");
+      }
     } catch (err) {
       console.error("刪除物件失敗", err);
       const message =

--- a/src/components/ItemListRow.tsx
+++ b/src/components/ItemListRow.tsx
@@ -36,12 +36,13 @@ export default function ItemListRow({ item }: ItemListRowProps) {
   const detailHref = `/item/${item.id}`;
 
   return (
-    <article className="rounded-2xl border border-gray-100 bg-white/85 p-4 shadow-sm">
-      <div className="flex flex-wrap items-center gap-4">
-        <Link
-          href={detailHref}
-          className="relative h-16 w-12 shrink-0 overflow-hidden rounded-lg border border-gray-200 bg-gray-100 shadow-inner"
-        >
+    <article className="w-full rounded-2xl border border-gray-100 bg-white/85 p-4 shadow-sm">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex flex-1 gap-4">
+          <Link
+            href={detailHref}
+            className="relative h-16 w-12 shrink-0 overflow-hidden rounded-lg border border-gray-200 bg-gray-100 shadow-inner"
+          >
           {item.thumbUrl ? (
             canUseOptimizedThumb ? (
               <Image
@@ -65,78 +66,81 @@ export default function ItemListRow({ item }: ItemListRowProps) {
               無封面
             </div>
           )}
-        </Link>
-
-        <div className="min-w-0 flex-1 space-y-1">
-          <Link
-            href={detailHref}
-            className="block truncate text-base font-semibold text-gray-900 transition hover:text-blue-600"
-          >
-            {item.titleZh}
           </Link>
-          {item.titleAlt && (
-            <div className="truncate text-xs text-gray-500">{item.titleAlt}</div>
-          )}
-          {tags.length > 0 && (
-            <div className="flex flex-wrap gap-2 pt-1 text-xs text-gray-600">
-              {tags.map((tag) => {
-                if (!item.cabinetId) {
+
+          <div className="min-w-0 flex-1 space-y-1">
+            <Link
+              href={detailHref}
+              className="block truncate text-base font-semibold text-gray-900 transition hover:text-blue-600"
+            >
+              {item.titleZh}
+            </Link>
+            {item.titleAlt && (
+              <div className="truncate text-xs text-gray-500">{item.titleAlt}</div>
+            )}
+            {tags.length > 0 && (
+              <div className="flex flex-wrap gap-2 pt-1 text-xs text-gray-600">
+                {tags.map((tag) => {
+                  if (!item.cabinetId) {
+                    return (
+                      <span
+                        key={tag}
+                        className="rounded-full border border-gray-200 bg-white px-3 py-1"
+                      >
+                        #{tag}
+                      </span>
+                    );
+                  }
+                  const tagHref = `/cabinet/${encodeURIComponent(
+                    item.cabinetId
+                  )}?tag=${encodeURIComponent(tag)}`;
                   return (
-                    <span
+                    <Link
                       key={tag}
-                      className="rounded-full border border-gray-200 bg-white px-3 py-1"
+                      href={tagHref}
+                      className="rounded-full border border-gray-200 bg-white px-3 py-1 transition hover:border-blue-400 hover:bg-blue-50 hover:text-blue-700"
                     >
                       #{tag}
-                    </span>
+                    </Link>
                   );
-                }
-                const tagHref = `/cabinet/${encodeURIComponent(
-                  item.cabinetId
-                )}?tag=${encodeURIComponent(tag)}`;
-                return (
-                  <Link
-                    key={tag}
-                    href={tagHref}
-                    className="rounded-full border border-gray-200 bg-white px-3 py-1 transition hover:border-blue-400 hover:bg-blue-50 hover:text-blue-700"
-                  >
-                    #{tag}
-                  </Link>
-                );
-              })}
-            </div>
-          )}
+                })}
+              </div>
+            )}
+          </div>
         </div>
 
-        <div className="flex flex-wrap items-center gap-3">
-          <div className="min-w-[96px] text-sm font-medium text-gray-700">
+        <div className="flex w-full flex-col gap-3 sm:w-auto sm:min-w-[160px] sm:flex-none sm:items-end">
+          <div className="text-sm font-medium text-gray-700 sm:text-right">
             {listDisplay}
           </div>
-          {primaryLink ? (
-            <a
-              href={primaryLink.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={buttonClass({ variant: "secondary", size: "sm" })}
-            >
-              點我觀看
-            </a>
-          ) : (
+          <div className="flex flex-wrap gap-2 sm:flex-nowrap sm:justify-end">
+            {primaryLink ? (
+              <a
+                href={primaryLink.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={`${buttonClass({ variant: "secondary", size: "sm" })} w-full sm:w-auto`}
+              >
+                點我觀看
+              </a>
+            ) : (
+              <button
+                type="button"
+                disabled
+                className={`${buttonClass({ variant: "secondary", size: "sm" })} w-full border-dashed text-gray-400 sm:w-auto`}
+              >
+                尚未提供連結
+              </button>
+            )}
             <button
               type="button"
-              disabled
-              className={`${buttonClass({ variant: "secondary", size: "sm" })} border-dashed text-gray-400`}
+              onClick={increment}
+              disabled={updating || loading}
+              className={`${buttonClass({ variant: "primary", size: "sm" })} w-full sm:w-auto`}
             >
-              尚未提供連結
+              {updating ? "+1…" : "+1"}
             </button>
-          )}
-          <button
-            type="button"
-            onClick={increment}
-            disabled={updating || loading}
-            className={buttonClass({ variant: "primary", size: "sm" })}
-          >
-            {updating ? "+1…" : "+1"}
-          </button>
+          </div>
         </div>
       </div>
 

--- a/src/components/ItemListRow.tsx
+++ b/src/components/ItemListRow.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useMemo } from "react";
+
+import { usePrimaryProgress } from "@/hooks/usePrimaryProgress";
+import { isOptimizedImageUrl } from "@/lib/image-utils";
+import type { ItemRecord } from "@/lib/types";
+import { buttonClass } from "@/lib/ui";
+
+type ItemListRowProps = {
+  item: ItemRecord;
+};
+
+export default function ItemListRow({ item }: ItemListRowProps) {
+  const { listDisplay, increment, updating, loading, error, success } =
+    usePrimaryProgress(item);
+
+  const primaryLink = useMemo(() => {
+    if (!item.links || item.links.length === 0) {
+      return null;
+    }
+    const validLinks = item.links.filter(
+      (link) => typeof link.url === "string" && link.url.trim().length > 0
+    );
+    if (validLinks.length === 0) {
+      return null;
+    }
+    const flagged = validLinks.find((link) => link.isPrimary);
+    return flagged ?? validLinks[0];
+  }, [item.links]);
+
+  const canUseOptimizedThumb = isOptimizedImageUrl(item.thumbUrl);
+
+  return (
+    <article className="rounded-2xl border border-gray-100 bg-white/85 p-4 shadow-sm">
+      <div className="flex flex-wrap items-center gap-4">
+        <Link
+          href={`/item/${item.id}`}
+          className="relative h-16 w-12 shrink-0 overflow-hidden rounded-lg border border-gray-200 bg-gray-100 shadow-inner"
+        >
+          {item.thumbUrl ? (
+            canUseOptimizedThumb ? (
+              <Image
+                src={item.thumbUrl}
+                alt={`${item.titleZh} 縮圖`}
+                fill
+                sizes="48px"
+                className="object-cover"
+              />
+            ) : (
+              /* eslint-disable-next-line @next/next/no-img-element */
+              <img
+                src={item.thumbUrl}
+                alt={`${item.titleZh} 縮圖`}
+                className="h-full w-full object-cover"
+                loading="lazy"
+              />
+            )
+          ) : (
+            <div className="flex h-full w-full items-center justify-center text-[10px] font-medium text-gray-400">
+              無封面
+            </div>
+          )}
+        </Link>
+
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-base font-semibold text-gray-900">
+            {item.titleZh}
+          </div>
+          {item.titleAlt && (
+            <div className="truncate text-xs text-gray-500">{item.titleAlt}</div>
+          )}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="min-w-[96px] text-sm font-medium text-gray-700">
+            {listDisplay}
+          </div>
+          {primaryLink ? (
+            <a
+              href={primaryLink.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={buttonClass({ variant: "secondary", size: "sm" })}
+            >
+              點我觀看
+            </a>
+          ) : (
+            <button
+              type="button"
+              disabled
+              className={`${buttonClass({ variant: "secondary", size: "sm" })} border-dashed text-gray-400`}
+            >
+              尚未提供連結
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={increment}
+            disabled={updating || loading}
+            className={buttonClass({ variant: "primary", size: "sm" })}
+          >
+            {updating ? "+1…" : "+1"}
+          </button>
+        </div>
+      </div>
+
+      {(error || success) && (
+        <div
+          className={`mt-3 rounded-xl px-3 py-2 text-xs ${
+            error ? "bg-red-50 text-red-700" : "bg-emerald-50 text-emerald-700"
+          }`}
+        >
+          {error ?? success}
+        </div>
+      )}
+    </article>
+  );
+}

--- a/src/components/ItemListRow.tsx
+++ b/src/components/ItemListRow.tsx
@@ -32,12 +32,14 @@ export default function ItemListRow({ item }: ItemListRowProps) {
   }, [item.links]);
 
   const canUseOptimizedThumb = isOptimizedImageUrl(item.thumbUrl);
+  const tags = item.tags ?? [];
+  const detailHref = `/item/${item.id}`;
 
   return (
     <article className="rounded-2xl border border-gray-100 bg-white/85 p-4 shadow-sm">
       <div className="flex flex-wrap items-center gap-4">
         <Link
-          href={`/item/${item.id}`}
+          href={detailHref}
           className="relative h-16 w-12 shrink-0 overflow-hidden rounded-lg border border-gray-200 bg-gray-100 shadow-inner"
         >
           {item.thumbUrl ? (
@@ -65,12 +67,43 @@ export default function ItemListRow({ item }: ItemListRowProps) {
           )}
         </Link>
 
-        <div className="min-w-0 flex-1">
-          <div className="truncate text-base font-semibold text-gray-900">
+        <div className="min-w-0 flex-1 space-y-1">
+          <Link
+            href={detailHref}
+            className="block truncate text-base font-semibold text-gray-900 transition hover:text-blue-600"
+          >
             {item.titleZh}
-          </div>
+          </Link>
           {item.titleAlt && (
             <div className="truncate text-xs text-gray-500">{item.titleAlt}</div>
+          )}
+          {tags.length > 0 && (
+            <div className="flex flex-wrap gap-2 pt-1 text-xs text-gray-600">
+              {tags.map((tag) => {
+                if (!item.cabinetId) {
+                  return (
+                    <span
+                      key={tag}
+                      className="rounded-full border border-gray-200 bg-white px-3 py-1"
+                    >
+                      #{tag}
+                    </span>
+                  );
+                }
+                const tagHref = `/cabinet/${encodeURIComponent(
+                  item.cabinetId
+                )}?tag=${encodeURIComponent(tag)}`;
+                return (
+                  <Link
+                    key={tag}
+                    href={tagHref}
+                    className="rounded-full border border-gray-200 bg-white px-3 py-1 transition hover:border-blue-400 hover:bg-blue-50 hover:text-blue-700"
+                  >
+                    #{tag}
+                  </Link>
+                );
+              })}
+            </div>
           )}
         </div>
 

--- a/src/hooks/usePrimaryProgress.ts
+++ b/src/hooks/usePrimaryProgress.ts
@@ -1,0 +1,175 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  collection,
+  doc,
+  increment,
+  limit,
+  onSnapshot,
+  query,
+  serverTimestamp,
+  Timestamp,
+  where,
+  writeBatch,
+} from "firebase/firestore";
+
+import { db } from "@/lib/firebase";
+import { calculateNextUpdateDate } from "@/lib/item-utils";
+import {
+  PROGRESS_TYPE_OPTIONS,
+  type ItemRecord,
+  type ProgressType,
+} from "@/lib/types";
+
+export type PrimaryProgressState = {
+  id: string;
+  platform: string;
+  type: ProgressType;
+  value: number;
+  unit?: string | null;
+  updatedAt?: Timestamp | null;
+};
+
+const progressTypeLabelMap = new Map(
+  PROGRESS_TYPE_OPTIONS.map((option) => [option.value, option.label])
+);
+
+function formatProgressValue(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
+function shouldUseOrdinal(unit: string | null | undefined, type: ProgressType): boolean {
+  if (!unit || unit.trim().length === 0) {
+    return type === "chapter" || type === "episode";
+  }
+  const normalized = unit.replace(/\s+/g, "");
+  return /^(話|集|頁|卷|冊|章|回|節|篇)$/u.test(normalized);
+}
+
+function formatListDisplay(primary: PrimaryProgressState | null, loading: boolean): string {
+  if (loading) {
+    return "主進度載入中…";
+  }
+  if (!primary) {
+    return "尚未設定";
+  }
+  const valueText = formatProgressValue(primary.value);
+  const unitText = primary.unit?.trim() ?? "";
+  if (shouldUseOrdinal(primary.unit, primary.type)) {
+    return unitText ? `第${valueText}${unitText}` : `第${valueText}`;
+  }
+  return unitText ? `${valueText}${unitText}` : valueText;
+}
+
+function formatSummary(primary: PrimaryProgressState | null, loading: boolean): string {
+  if (loading) {
+    return "主進度載入中…";
+  }
+  if (!primary) {
+    return "尚未設定主進度";
+  }
+  const typeLabel = progressTypeLabelMap.get(primary.type) ?? primary.type;
+  const valueText = formatProgressValue(primary.value);
+  const unitText = primary.unit ? ` ${primary.unit}` : "";
+  return `${primary.platform || "未命名平台"}｜${typeLabel} ${valueText}${unitText}`;
+}
+
+export function usePrimaryProgress(item: ItemRecord) {
+  const [primary, setPrimary] = useState<PrimaryProgressState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [updating, setUpdating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  useEffect(() => {
+    const progressQuery = query(
+      collection(db, "item", item.id, "progress"),
+      where("isPrimary", "==", true),
+      limit(1)
+    );
+    const unsub = onSnapshot(
+      progressQuery,
+      (snap) => {
+        if (snap.empty) {
+          setPrimary(null);
+        } else {
+          const docSnap = snap.docs[0];
+          const data = docSnap.data();
+          const typeValue =
+            typeof data.type === "string" && progressTypeLabelMap.has(data.type as ProgressType)
+              ? (data.type as ProgressType)
+              : "chapter";
+          setPrimary({
+            id: docSnap.id,
+            platform: typeof data.platform === "string" ? data.platform : "",
+            type: typeValue,
+            value:
+              typeof data.value === "number" && Number.isFinite(data.value) ? data.value : 0,
+            unit: typeof data.unit === "string" ? data.unit : null,
+            updatedAt: data.updatedAt instanceof Timestamp ? (data.updatedAt as Timestamp) : null,
+          });
+        }
+        setLoading(false);
+        setError(null);
+      },
+      (err) => {
+        console.error("載入主進度失敗", err);
+        setError("載入主進度失敗");
+        setLoading(false);
+      }
+    );
+    return () => unsub();
+  }, [item.id]);
+
+  useEffect(() => {
+    if (!success) return;
+    const timer = setTimeout(() => setSuccess(null), 2500);
+    return () => clearTimeout(timer);
+  }, [success]);
+
+  const summary = useMemo(() => formatSummary(primary, loading), [primary, loading]);
+  const listDisplay = useMemo(() => formatListDisplay(primary, loading), [primary, loading]);
+
+  const handleIncrement = useCallback(async () => {
+    if (!primary) {
+      setError("尚未設定主進度，請先在物件頁面新增並設定主進度。");
+      return;
+    }
+    setError(null);
+    setSuccess(null);
+    setUpdating(true);
+    try {
+      const batch = writeBatch(db);
+      const progressRef = doc(db, "item", item.id, "progress", primary.id);
+      batch.update(progressRef, {
+        value: increment(1),
+        updatedAt: serverTimestamp(),
+      });
+      const nextDate = calculateNextUpdateDate(item.updateFrequency ?? null);
+      const itemRef = doc(db, "item", item.id);
+      batch.update(itemRef, {
+        updatedAt: serverTimestamp(),
+        nextUpdateAt: nextDate ? Timestamp.fromDate(nextDate) : null,
+      });
+      await batch.commit();
+      setSuccess("已更新主進度");
+    } catch (err) {
+      console.error("更新主進度時發生錯誤", err);
+      setError("更新主進度時發生錯誤");
+    } finally {
+      setUpdating(false);
+    }
+  }, [primary, item.id, item.updateFrequency]);
+
+  return {
+    primary,
+    loading,
+    summary,
+    listDisplay,
+    updating,
+    error,
+    success,
+    increment: handleIncrement,
+    setError,
+    setSuccess,
+  };
+}

--- a/src/lib/firestore-utils.ts
+++ b/src/lib/firestore-utils.ts
@@ -9,13 +9,22 @@ import {
   where,
   type QuerySnapshot,
   type DocumentData,
+  type DocumentSnapshot,
 } from "firebase/firestore";
 
 import { db } from "./firebase";
 
 export async function deleteItemWithProgress(itemId: string, userId?: string) {
   const itemRef = doc(db, "item", itemId);
-  const snap = await getDoc(itemRef);
+  let snap: DocumentSnapshot<DocumentData>;
+  try {
+    snap = await getDoc(itemRef);
+  } catch (err) {
+    if (err instanceof FirebaseError && err.code === "permission-denied") {
+      throw new Error("讀取物件資料時遭到拒絕，請稍後再試或確認帳號權限。");
+    }
+    throw err;
+  }
   if (!snap.exists()) {
     return;
   }

--- a/src/lib/image-utils.ts
+++ b/src/lib/image-utils.ts
@@ -1,0 +1,9 @@
+export function isOptimizedImageUrl(url?: string | null): boolean {
+  if (!url) return false;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" && parsed.hostname === "i.imgur.com";
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -58,6 +58,12 @@ export type ItemLink = {
   isPrimary?: boolean;
 };
 
+export type AppearanceRecord = {
+  name: string;
+  thumbUrl?: string | null;
+  note?: string | null;
+};
+
 export type ItemRecord = {
   id: string;
   uid: string;
@@ -71,6 +77,7 @@ export type ItemRecord = {
   progressNote?: string | null;
   insightNote?: string | null;
   note?: string | null;
+  appearances: AppearanceRecord[];
   rating?: number | null;
   status: ItemStatus;
   updateFrequency?: UpdateFrequency | null;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -69,6 +69,7 @@ export type ItemRecord = {
   links: ItemLink[];
   thumbUrl?: string | null;
   progressNote?: string | null;
+  insightNote?: string | null;
   note?: string | null;
   rating?: number | null;
   status: ItemStatus;

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -17,6 +17,7 @@ export type ItemFormInput = {
   links?: ItemLink[] | undefined;
   thumbUrl?: string | undefined;
   progressNote?: string | undefined;
+  insightNote?: string | undefined;
   note?: string | undefined;
   rating?: number | null | undefined;
   status: ItemStatus;
@@ -33,6 +34,7 @@ export type ItemFormData = {
   links: ItemLink[];
   thumbUrl?: string;
   progressNote?: string;
+  insightNote?: string;
   note?: string;
   rating?: number;
   status: ItemStatus;
@@ -188,6 +190,13 @@ export function parseItemForm(input: ItemFormInput): ItemFormData {
     const progressNote = assertString(input.progressNote, "進度備註格式錯誤").trim();
     if (progressNote) {
       data.progressNote = progressNote;
+    }
+  }
+
+  if (input.insightNote) {
+    const insightNote = assertString(input.insightNote, "心得/筆記格式錯誤").trim();
+    if (insightNote) {
+      data.insightNote = insightNote;
     }
   }
 

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -150,7 +150,7 @@ export function parseItemForm(input: ItemFormInput): ItemFormData {
     const tags = input.tags
       .map((tag) => assertString(tag, "標籤需為文字").trim())
       .filter(Boolean);
-    data.tags = tags;
+    data.tags = Array.from(new Set(tags));
   }
 
   if (input.links) {


### PR DESCRIPTION
## Summary
- add multi-tag filtering controls to cabinet item list and compute available tags
- extend item data with an insight/note field, updating forms, validation, and the detail page display
- display tags horizontally on cards and tweak the primary link helper text on the detail page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca414d65248320a1d365b4b428d7fd