### PR TITLE
Fix Firebase env detection

### DIFF
--- a/src/app/cabinet/[id]/edit/page.tsx
+++ b/src/app/cabinet/[id]/edit/page.tsx
@@ -16,7 +16,7 @@ import {
   writeBatch,
 } from "firebase/firestore";
 
-import { auth, db } from "@/lib/firebase";
+import { getFirebaseAuth, getFirebaseDb } from "@/lib/firebase";
 import { deleteCabinetWithItems } from "@/lib/firestore-utils";
 
 type CabinetEditPageProps = {
@@ -58,6 +58,13 @@ export default function CabinetEditPage({ params }: CabinetEditPageProps) {
   const [editingValue, setEditingValue] = useState("");
 
   useEffect(() => {
+    const auth = getFirebaseAuth();
+    if (!auth) {
+      setAuthChecked(true);
+      setLoading(false);
+      setError("Firebase 尚未設定");
+      return undefined;
+    }
     const unsub = onAuthStateChanged(auth, (current) => {
       setUser(current);
       setAuthChecked(true);
@@ -85,6 +92,14 @@ export default function CabinetEditPage({ params }: CabinetEditPageProps) {
     setError(null);
     setDeleteError(null);
     setMessage(null);
+    const db = getFirebaseDb();
+    if (!db) {
+      setError("Firebase 尚未設定");
+      setCanEdit(false);
+      setLoading(false);
+      setTags([]);
+      return;
+    }
     const cabinetRef = doc(db, "cabinet", cabinetId);
     getDoc(cabinetRef)
       .then((snap) => {
@@ -140,6 +155,12 @@ export default function CabinetEditPage({ params }: CabinetEditPageProps) {
     setSaving(true);
     setError(null);
     try {
+      const db = getFirebaseDb();
+      if (!db) {
+        setError("Firebase 尚未設定");
+        setSaving(false);
+        return;
+      }
       const cabinetRef = doc(db, "cabinet", cabinetId);
       await updateDoc(cabinetRef, {
         name: trimmed,
@@ -185,6 +206,12 @@ export default function CabinetEditPage({ params }: CabinetEditPageProps) {
     setTagMessage(null);
     try {
       const nextTags = normalizeCabinetTags([...tags, trimmed]);
+      const db = getFirebaseDb();
+      if (!db) {
+        setTagError("Firebase 尚未設定");
+        setTagSaving(false);
+        return;
+      }
       const cabinetRef = doc(db, "cabinet", cabinetId);
       await updateDoc(cabinetRef, {
         tags: nextTags,
@@ -214,6 +241,11 @@ export default function CabinetEditPage({ params }: CabinetEditPageProps) {
     if (trimmed !== target && tags.includes(trimmed)) {
       setTagError("已有相同標籤");
       setTagMessage(null);
+      return;
+    }
+    const db = getFirebaseDb();
+    if (!db) {
+      setTagError("Firebase 尚未設定");
       return;
     }
     setTagSaving(true);
@@ -273,6 +305,11 @@ export default function CabinetEditPage({ params }: CabinetEditPageProps) {
       return;
     }
     if (!window.confirm(`確認刪除標籤「${target}」？`)) {
+      return;
+    }
+    const db = getFirebaseDb();
+    if (!db) {
+      setTagError("Firebase 尚未設定");
       return;
     }
     setTagSaving(true);

--- a/src/app/item/[id]/page.tsx
+++ b/src/app/item/[id]/page.tsx
@@ -14,7 +14,8 @@ import {
   Timestamp,
   where,
 } from "firebase/firestore";
-import { auth, db } from "@/lib/firebase";
+import { normalizeAppearanceRecords } from "@/lib/appearances";
+import { getFirebaseAuth, getFirebaseDb } from "@/lib/firebase";
 import { buttonClass } from "@/lib/ui";
 import {
   ITEM_STATUS_OPTIONS,
@@ -97,6 +98,15 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
   const [progressError, setProgressError] = useState<string | null>(null);
 
   useEffect(() => {
+    const auth = getFirebaseAuth();
+    if (!auth) {
+      setAuthChecked(true);
+      setItemLoading(false);
+      setProgressLoading(false);
+      setItemError("Firebase 尚未設定");
+      setProgressError("Firebase 尚未設定");
+      return undefined;
+    }
     const unsub = onAuthStateChanged(auth, (current) => {
       setUser(current);
       setAuthChecked(true);
@@ -118,6 +128,12 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
     setItemError(null);
     (async () => {
       try {
+        const db = getFirebaseDb();
+        if (!db) {
+          setItemError("Firebase 尚未設定");
+          setItemLoading(false);
+          return;
+        }
         const itemRef = doc(db, "item", itemId);
         const snap = await getDoc(itemRef);
         if (!active) return;
@@ -182,43 +198,7 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
               return normalized;
             })()
           : [];
-        const appearances = Array.isArray(data.appearances)
-          ? data.appearances
-              .map((entry) => {
-                if (!entry || typeof entry !== "object") {
-                  return null;
-                }
-                const recordEntry = entry as {
-                  name?: unknown;
-                  thumbUrl?: unknown;
-                  note?: unknown;
-                };
-                const name =
-                  typeof recordEntry.name === "string"
-                    ? recordEntry.name.trim()
-                    : "";
-                if (!name) {
-                  return null;
-                }
-                const thumbUrl =
-                  typeof recordEntry.thumbUrl === "string"
-                    ? recordEntry.thumbUrl.trim()
-                    : "";
-                const note =
-                  typeof recordEntry.note === "string"
-                    ? recordEntry.note.trim()
-                    : "";
-                return {
-                  name,
-                  thumbUrl: thumbUrl || null,
-                  note: note || null,
-                };
-              })
-              .filter(
-                (entry): entry is { name: string; thumbUrl?: string | null; note?: string | null } =>
-                  Boolean(entry)
-              )
-          : [];
+        const appearances = normalizeAppearanceRecords(data.appearances);
         const record: ItemRecord = {
           id: snap.id,
           uid: typeof data.uid === "string" ? data.uid : user.uid,
@@ -290,6 +270,12 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
     }
     setProgressLoading(true);
     setProgressError(null);
+    const db = getFirebaseDb();
+    if (!db) {
+      setProgressError("Firebase 尚未設定");
+      setProgressLoading(false);
+      return;
+    }
     const progressQuery = query(
       collection(db, "item", itemId, "progress"),
       where("isPrimary", "==", true),

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -2,7 +2,7 @@
 
 import { FormEvent, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { auth } from "@/lib/firebase";
+import { getFirebaseAuth } from "@/lib/firebase";
 import {
   onAuthStateChanged,
   signInWithEmailAndPassword,
@@ -30,6 +30,11 @@ export default function LoginPage() {
   const [signingOut, setSigningOut] = useState(false);
 
   useEffect(() => {
+    const auth = getFirebaseAuth();
+    if (!auth) {
+      setAuthReady(true);
+      return undefined;
+    }
     const unSub = onAuthStateChanged(auth, (current) => {
       setUser(current);
       setAuthReady(true);
@@ -68,6 +73,12 @@ export default function LoginPage() {
 
     setLoading(true);
     try {
+      const auth = getFirebaseAuth();
+      if (!auth) {
+        setError("Firebase 尚未設定");
+        setLoading(false);
+        return;
+      }
       if (mode === "login") {
         await signInWithEmailAndPassword(auth, trimmedEmail, pw);
         setMessage("登入成功，正在前往櫃子");
@@ -107,6 +118,10 @@ export default function LoginPage() {
     setError(null);
     setMessage(null);
     try {
+      const auth = getFirebaseAuth();
+      if (!auth) {
+        throw new Error("Firebase 尚未設定");
+      }
       await signOut(auth);
       setMessage("已登出，歡迎再次使用");
       router.push("/");

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -5,7 +5,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { onAuthStateChanged, signOut, type User } from "firebase/auth";
 
-import { auth } from "@/lib/firebase";
+import { getFirebaseAuth } from "@/lib/firebase";
 
 const baseLinkClass =
   "rounded-full px-3 py-2 text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400";
@@ -22,6 +22,12 @@ export default function AppHeader() {
   const [signingOut, setSigningOut] = useState(false);
 
   useEffect(() => {
+    const auth = getFirebaseAuth();
+    if (!auth) {
+      setAuthReady(true);
+      return undefined;
+    }
+
     const unsub = onAuthStateChanged(auth, (current) => {
       setUser(current);
       setAuthReady(true);
@@ -42,6 +48,10 @@ export default function AppHeader() {
     if (signingOut) return;
     setSigningOut(true);
     try {
+      const auth = getFirebaseAuth();
+      if (!auth) {
+        throw new Error("Firebase 尚未設定，無法登出");
+      }
       await signOut(auth);
       router.push("/");
       router.refresh();

--- a/src/components/ItemForm.tsx
+++ b/src/components/ItemForm.tsx
@@ -25,7 +25,8 @@ import {
   updateDoc,
   where,
 } from "firebase/firestore";
-import { auth, db } from "@/lib/firebase";
+import { normalizeAppearanceRecords } from "@/lib/appearances";
+import { getFirebaseAuth, getFirebaseDb } from "@/lib/firebase";
 import ThumbLinkField from "./ThumbLinkField";
 import ProgressEditor from "./ProgressEditor";
 import {
@@ -85,30 +86,12 @@ function generateLocalId(): string {
 }
 
 function mapFirestoreAppearances(value: unknown): AppearanceState[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-  return value
-    .map((entry) => {
-      if (!entry || typeof entry !== "object") {
-        return null;
-      }
-      const record = entry as { name?: unknown; thumbUrl?: unknown; note?: unknown };
-      const name = typeof record.name === "string" ? record.name.trim() : "";
-      const thumbUrl =
-        typeof record.thumbUrl === "string" ? record.thumbUrl.trim() : "";
-      const note = typeof record.note === "string" ? record.note.trim() : "";
-      if (!name && !thumbUrl && !note) {
-        return null;
-      }
-      return {
-        id: generateLocalId(),
-        name,
-        thumbUrl,
-        note,
-      } satisfies AppearanceState;
-    })
-    .filter((entry): entry is AppearanceState => Boolean(entry));
+  return normalizeAppearanceRecords(value).map((entry) => ({
+    id: generateLocalId(),
+    name: entry.name,
+    thumbUrl: entry.thumbUrl ?? "",
+    note: entry.note ?? "",
+  }));
 }
 
 function mapFormAppearances(list: AppearanceFormData[]): AppearanceState[] {
@@ -236,6 +219,10 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
         }
       }
       try {
+        const db = getFirebaseDb();
+        if (!db) {
+          return [];
+        }
         const snap = await getDoc(doc(db, "cabinet", cabinetId));
         if (!snap.exists()) {
           return [];
@@ -254,6 +241,13 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
   );
 
   useEffect(() => {
+    const auth = getFirebaseAuth();
+    if (!auth) {
+      setAuthChecked(true);
+      setError("Firebase 尚未設定");
+      setLoading(false);
+      return undefined;
+    }
     const unsub = onAuthStateChanged(auth, (current) => {
       setUser(current);
       setAuthChecked(true);
@@ -267,6 +261,12 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
       return;
     }
     let active = true;
+    const db = getFirebaseDb();
+    if (!db) {
+      setError("Firebase 尚未設定");
+      setCabinets([]);
+      return;
+    }
     const q = query(collection(db, "cabinet"), where("uid", "==", user.uid));
     getDocs(q)
       .then((snap) => {
@@ -307,6 +307,12 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
     if (!user || !itemId) return;
     let active = true;
     setLoading(true);
+    const db = getFirebaseDb();
+    if (!db) {
+      setError("Firebase 尚未設定");
+      setLoading(false);
+      return;
+    }
     getDoc(doc(db, "item", itemId))
       .then((snap) => {
         if (!active) return;
@@ -641,6 +647,10 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
         updatedAt: serverTimestamp(),
       };
 
+      const db = getFirebaseDb();
+      if (!db) {
+        throw new Error("Firebase 尚未設定");
+      }
       if (mode === "edit" && itemId) {
         await updateDoc(doc(db, "item", itemId), docData);
         setMessage("已儲存");
@@ -686,6 +696,8 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
       setAppearances(mapFormAppearances(parsedData.appearances));
     } catch (err) {
       if (err instanceof ValidationError) {
+        setError(err.message);
+      } else if (err instanceof Error && err.message) {
         setError(err.message);
       } else {
         setError("儲存時發生錯誤");
@@ -770,6 +782,10 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
     setCabinetTags(nextTags);
     tagsCacheRef.current[form.cabinetId] = nextTags;
     try {
+      const db = getFirebaseDb();
+      if (!db) {
+        throw new Error("Firebase 尚未設定");
+      }
       await updateDoc(doc(db, "cabinet", form.cabinetId), {
         tags: nextTags,
         updatedAt: serverTimestamp(),
@@ -777,11 +793,11 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
       setTagStatus({ message: `已新增 #${value}`, error: null, saving: false });
     } catch (err) {
       console.error("新增標籤失敗", err);
-      setTagStatus({
-        message: null,
-        error: "新增標籤時發生錯誤，請稍後再試",
-        saving: false,
-      });
+      const message =
+        err instanceof Error && err.message
+          ? err.message
+          : "新增標籤時發生錯誤，請稍後再試";
+      setTagStatus({ message: null, error: message, saving: false });
       setCabinetTags(previousTags);
       tagsCacheRef.current[form.cabinetId] = previousTags;
       setForm((prev) => ({

--- a/src/hooks/usePrimaryProgress.ts
+++ b/src/hooks/usePrimaryProgress.ts
@@ -12,7 +12,7 @@ import {
   writeBatch,
 } from "firebase/firestore";
 
-import { db } from "@/lib/firebase";
+import { getFirebaseDb } from "@/lib/firebase";
 import { calculateNextUpdateDate } from "@/lib/item-utils";
 import {
   PROGRESS_TYPE_OPTIONS,
@@ -81,6 +81,12 @@ export function usePrimaryProgress(item: ItemRecord) {
   const [success, setSuccess] = useState<string | null>(null);
 
   useEffect(() => {
+    const db = getFirebaseDb();
+    if (!db) {
+      setError("Firebase 尚未設定");
+      setLoading(false);
+      return undefined;
+    }
     const progressQuery = query(
       collection(db, "item", item.id, "progress"),
       where("isPrimary", "==", true),
@@ -138,6 +144,10 @@ export function usePrimaryProgress(item: ItemRecord) {
     setSuccess(null);
     setUpdating(true);
     try {
+      const db = getFirebaseDb();
+      if (!db) {
+        throw new Error("Firebase 尚未設定");
+      }
       const batch = writeBatch(db);
       const progressRef = doc(db, "item", item.id, "progress", primary.id);
       batch.update(progressRef, {

--- a/src/lib/appearances.ts
+++ b/src/lib/appearances.ts
@@ -1,0 +1,36 @@
+import type { AppearanceRecord } from "./types";
+
+export function normalizeAppearanceRecords(value: unknown): AppearanceRecord[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const result: AppearanceRecord[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+    const record = entry as {
+      name?: unknown;
+      thumbUrl?: unknown;
+      note?: unknown;
+    };
+    const name =
+      typeof record.name === "string" ? record.name.trim() : "";
+    if (!name) {
+      continue;
+    }
+    const thumbUrl =
+      typeof record.thumbUrl === "string" ? record.thumbUrl.trim() : "";
+    const note =
+      typeof record.note === "string" ? record.note.trim() : "";
+
+    result.push({
+      name,
+      thumbUrl: thumbUrl || null,
+      note: note || null,
+    });
+  }
+
+  return result;
+}

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,37 +1,145 @@
-// src/lib/firebase.ts
-console.log("ENV apiKey:", process.env.NEXT_PUBLIC_FIREBASE_API_KEY);
-if (!process.env.NEXT_PUBLIC_FIREBASE_API_KEY) {
-  throw new Error(
-    "ENV 未載入：缺少 NEXT_PUBLIC_FIREBASE_API_KEY（請檢查 .env.local 位置與鍵名）"
-  );
-}
-
-import { initializeApp, getApps, getApp } from "firebase/app";
+import { getApp, getApps, initializeApp, type FirebaseApp } from "firebase/app";
 import {
   initializeFirestore,
   persistentLocalCache,
   persistentMultipleTabManager,
+  type Firestore,
 } from "firebase/firestore";
-import { getAuth } from "firebase/auth";
-import { getStorage } from "firebase/storage";
+import { getAuth, type Auth } from "firebase/auth";
+import { getStorage, type FirebaseStorage } from "firebase/storage";
 
-const firebaseConfig = {
-  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY!,
-  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN!,
-  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID!,
-  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET!,
-  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID!,
-  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID!,
-};
+type Nullable<T> = T | null;
 
-const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
+type FirebaseEnvKey =
+  | "NEXT_PUBLIC_FIREBASE_API_KEY"
+  | "NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN"
+  | "NEXT_PUBLIC_FIREBASE_PROJECT_ID"
+  | "NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET"
+  | "NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID"
+  | "NEXT_PUBLIC_FIREBASE_APP_ID";
 
-// 行動端優先：開啟離線快取
-export const db = initializeFirestore(app, {
-  localCache: persistentLocalCache({
-    tabManager: persistentMultipleTabManager(),
-  }),
-});
-export const auth = getAuth(app);
-export const storage = getStorage(app);
-export default app;
+const REQUIRED_ENV_KEYS: FirebaseEnvKey[] = [
+  "NEXT_PUBLIC_FIREBASE_API_KEY",
+  "NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN",
+  "NEXT_PUBLIC_FIREBASE_PROJECT_ID",
+  "NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET",
+  "NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID",
+  "NEXT_PUBLIC_FIREBASE_APP_ID",
+];
+
+let hasLoggedMissingConfig = false;
+
+function readFirebaseConfig(): Nullable<{
+  apiKey: string;
+  authDomain: string;
+  projectId: string;
+  storageBucket: string;
+  messagingSenderId: string;
+  appId: string;
+}> {
+  const envValues: Record<FirebaseEnvKey, string | undefined> = {
+    NEXT_PUBLIC_FIREBASE_API_KEY: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+    NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+    NEXT_PUBLIC_FIREBASE_PROJECT_ID: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+    NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+    NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID:
+      process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+    NEXT_PUBLIC_FIREBASE_APP_ID: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  };
+
+  const missingKeys = REQUIRED_ENV_KEYS.filter((key) => !envValues[key]);
+
+  if (missingKeys.length > 0) {
+    if (!hasLoggedMissingConfig && process.env.NODE_ENV !== "test") {
+      hasLoggedMissingConfig = true;
+      console.warn(
+        `Firebase 環境變數缺失：${missingKeys.join(", ")}`,
+        "請確認 .env.local 是否存在並包含所需設定。"
+      );
+    }
+    return null;
+  }
+
+  hasLoggedMissingConfig = false;
+  return {
+    apiKey: envValues.NEXT_PUBLIC_FIREBASE_API_KEY!,
+    authDomain: envValues.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN!,
+    projectId: envValues.NEXT_PUBLIC_FIREBASE_PROJECT_ID!,
+    storageBucket: envValues.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET!,
+    messagingSenderId: envValues.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID!,
+    appId: envValues.NEXT_PUBLIC_FIREBASE_APP_ID!,
+  } as const;
+}
+
+function createFirebaseApp(): Nullable<FirebaseApp> {
+  const config = readFirebaseConfig();
+  if (!config) {
+    return null;
+  }
+  return getApps().length ? getApp() : initializeApp(config);
+}
+
+let cachedApp: Nullable<FirebaseApp> = null;
+let cachedDb: Nullable<Firestore> = null;
+let cachedAuth: Nullable<Auth> = null;
+let cachedStorage: Nullable<FirebaseStorage> = null;
+
+export function getFirebaseApp(): Nullable<FirebaseApp> {
+  if (cachedApp) {
+    return cachedApp;
+  }
+
+  const app = createFirebaseApp();
+  if (app) {
+    cachedApp = app;
+  }
+  return app;
+}
+
+export function getFirebaseDb(): Nullable<Firestore> {
+  if (cachedDb) {
+    return cachedDb;
+  }
+
+  const app = getFirebaseApp();
+  if (!app) {
+    return null;
+  }
+
+  cachedDb = initializeFirestore(app, {
+    localCache: persistentLocalCache({
+      tabManager: persistentMultipleTabManager(),
+    }),
+  });
+  return cachedDb;
+}
+
+export function getFirebaseAuth(): Nullable<Auth> {
+  if (cachedAuth) {
+    return cachedAuth;
+  }
+
+  const app = getFirebaseApp();
+  if (!app) {
+    return null;
+  }
+
+  cachedAuth = getAuth(app);
+  return cachedAuth;
+}
+
+export function getFirebaseStorage(): Nullable<FirebaseStorage> {
+  if (cachedStorage) {
+    return cachedStorage;
+  }
+
+  const app = getFirebaseApp();
+  if (!app) {
+    return null;
+  }
+
+  cachedStorage = getStorage(app);
+  return cachedStorage;
+}
+
+export default getFirebaseApp;

--- a/src/lib/firestore-utils.ts
+++ b/src/lib/firestore-utils.ts
@@ -12,9 +12,13 @@ import {
   type DocumentSnapshot,
 } from "firebase/firestore";
 
-import { db } from "./firebase";
+import { getFirebaseDb } from "./firebase";
 
 export async function deleteItemWithProgress(itemId: string, userId?: string) {
+  const db = getFirebaseDb();
+  if (!db) {
+    throw new Error("Firebase 尚未設定");
+  }
   const itemRef = doc(db, "item", itemId);
   let snap: DocumentSnapshot<DocumentData>;
   try {
@@ -64,6 +68,10 @@ export async function deleteItemWithProgress(itemId: string, userId?: string) {
 }
 
 export async function deleteCabinetWithItems(cabinetId: string, userId: string) {
+  const db = getFirebaseDb();
+  if (!db) {
+    throw new Error("Firebase 尚未設定");
+  }
   const cabinetRef = doc(db, "cabinet", cabinetId);
   const snap = await getDoc(cabinetRef);
   if (!snap.exists()) {


### PR DESCRIPTION
## Summary
- read Firebase env variables using static property access so Next.js replaces them during builds
- reuse the collected env values when constructing the Firebase config to avoid false “Firebase 尚未設定” warnings
- allow Firebase initialization to re-run when configuration becomes available so auth calls reach the backend

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca6facc1448320b31114c48e9e34e0