### PR TITLE
Add quick item creation page

### DIFF
--- a/src/app/cabinet/[id]/edit/page.tsx
+++ b/src/app/cabinet/[id]/edit/page.tsx
@@ -45,6 +45,7 @@ export default function CabinetEditPage({ params }: CabinetEditPageProps) {
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [name, setName] = useState("");
+  const [note, setNote] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
@@ -77,6 +78,7 @@ export default function CabinetEditPage({ params }: CabinetEditPageProps) {
       setLoading(false);
       setCanEdit(false);
       setName("");
+      setNote("");
       setMessage(null);
       setDeleteError(null);
       setTags([]);
@@ -108,6 +110,7 @@ export default function CabinetEditPage({ params }: CabinetEditPageProps) {
           setError("找不到櫃子");
           setCanEdit(false);
           setLoading(false);
+          setNote("");
           setTags([]);
           return;
         }
@@ -116,6 +119,7 @@ export default function CabinetEditPage({ params }: CabinetEditPageProps) {
           setError("您沒有存取此櫃子的權限");
           setCanEdit(false);
           setLoading(false);
+          setNote("");
           setTags([]);
           return;
         }
@@ -124,6 +128,11 @@ export default function CabinetEditPage({ params }: CabinetEditPageProps) {
             ? data.name
             : "";
         setName(nameValue);
+        const noteValue =
+          typeof data?.note === "string" && data.note.trim().length > 0
+            ? data.note.trim()
+            : "";
+        setNote(noteValue);
         setCanEdit(true);
         setTags(normalizeCabinetTags(data?.tags));
         setLoading(false);
@@ -133,6 +142,7 @@ export default function CabinetEditPage({ params }: CabinetEditPageProps) {
         setError("載入櫃子資料時發生錯誤");
         setCanEdit(false);
         setLoading(false);
+        setNote("");
         setTags([]);
       });
     return () => {
@@ -152,6 +162,7 @@ export default function CabinetEditPage({ params }: CabinetEditPageProps) {
       setMessage("名稱不可為空");
       return;
     }
+    const trimmedNote = note.trim();
     setSaving(true);
     setError(null);
     try {
@@ -164,10 +175,12 @@ export default function CabinetEditPage({ params }: CabinetEditPageProps) {
       const cabinetRef = doc(db, "cabinet", cabinetId);
       await updateDoc(cabinetRef, {
         name: trimmed,
+        note: trimmedNote ? trimmedNote : null,
         updatedAt: serverTimestamp(),
       });
       setName(trimmed);
-      setMessage("已更新櫃子名稱");
+      setNote(trimmedNote);
+      setMessage("已更新櫃子資料");
     } catch (err) {
       console.error("更新櫃子名稱失敗", err);
       setMessage("儲存櫃子資料時發生錯誤");
@@ -470,6 +483,15 @@ export default function CabinetEditPage({ params }: CabinetEditPageProps) {
                 onChange={(event) => setName(event.target.value)}
                 placeholder="例如：漫畫、小說、遊戲"
                 className={inputClass}
+              />
+            </label>
+            <label className="space-y-2">
+              <span className="text-sm text-gray-600">櫃子備註</span>
+              <textarea
+                value={note}
+                onChange={(event) => setNote(event.target.value)}
+                placeholder="補充說明、整理方式或其他提醒"
+                className="min-h-[100px] w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-base text-gray-900 shadow-sm focus:border-gray-300 focus:outline-none"
               />
             </label>
             <p className="text-xs text-gray-500">

--- a/src/app/cabinet/[id]/edit/page.tsx
+++ b/src/app/cabinet/[id]/edit/page.tsx
@@ -4,17 +4,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { FormEvent, use, useEffect, useState } from "react";
 import { onAuthStateChanged, type User } from "firebase/auth";
-import {
-  collection,
-  doc,
-  getDoc,
-  getDocs,
-  query,
-  serverTimestamp,
-  updateDoc,
-  where,
-  writeBatch,
-} from "firebase/firestore";
+import { doc, getDoc, serverTimestamp, updateDoc } from "firebase/firestore";
 
 import { getFirebaseAuth, getFirebaseDb } from "@/lib/firebase";
 import { deleteCabinetWithItems } from "@/lib/firestore-utils";
@@ -22,19 +12,6 @@ import { deleteCabinetWithItems } from "@/lib/firestore-utils";
 type CabinetEditPageProps = {
   params: Promise<{ id: string }>;
 };
-
-function normalizeCabinetTags(input: unknown): string[] {
-  if (!Array.isArray(input)) {
-    return [];
-  }
-  return Array.from(
-    new Set(
-      input
-        .map((tag) => String(tag ?? "").trim())
-        .filter((tag): tag is string => tag.length > 0)
-    )
-  ).sort((a, b) => a.localeCompare(b, "zh-Hant"));
-}
 
 export default function CabinetEditPage({ params }: CabinetEditPageProps) {
   const { id: cabinetId } = use(params);
@@ -50,13 +27,6 @@ export default function CabinetEditPage({ params }: CabinetEditPageProps) {
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
   const [canEdit, setCanEdit] = useState(false);
-  const [tags, setTags] = useState<string[]>([]);
-  const [tagInput, setTagInput] = useState("");
-  const [tagError, setTagError] = useState<string | null>(null);
-  const [tagMessage, setTagMessage] = useState<string | null>(null);
-  const [tagSaving, setTagSaving] = useState(false);
-  const [editingTag, setEditingTag] = useState<string | null>(null);
-  const [editingValue, setEditingValue] = useState("");
 
   useEffect(() => {
     const auth = getFirebaseAuth();
@@ -81,12 +51,6 @@ export default function CabinetEditPage({ params }: CabinetEditPageProps) {
       setNote("");
       setMessage(null);
       setDeleteError(null);
-      setTags([]);
-      setTagInput("");
-      setTagMessage(null);
-      setTagError(null);
-      setEditingTag(null);
-      setEditingValue("");
       return;
     }
     let active = true;
@@ -99,7 +63,6 @@ export default function CabinetEditPage({ params }: CabinetEditPageProps) {
       setError("Firebase 尚未設定");
       setCanEdit(false);
       setLoading(false);
-      setTags([]);
       return;
     }
     const cabinetRef = doc(db, "cabinet", cabinetId);
@@ -111,7 +74,6 @@ export default function CabinetEditPage({ params }: CabinetEditPageProps) {
           setCanEdit(false);
           setLoading(false);
           setNote("");
-          setTags([]);
           return;
         }
         const data = snap.data();
@@ -120,7 +82,6 @@ export default function CabinetEditPage({ params }: CabinetEditPageProps) {
           setCanEdit(false);
           setLoading(false);
           setNote("");
-          setTags([]);
           return;
         }
         const nameValue =
@@ -134,7 +95,6 @@ export default function CabinetEditPage({ params }: CabinetEditPageProps) {
             : "";
         setNote(noteValue);
         setCanEdit(true);
-        setTags(normalizeCabinetTags(data?.tags));
         setLoading(false);
       })
       .catch(() => {
@@ -143,7 +103,6 @@ export default function CabinetEditPage({ params }: CabinetEditPageProps) {
         setCanEdit(false);
         setLoading(false);
         setNote("");
-        setTags([]);
       });
     return () => {
       active = false;
@@ -198,177 +157,6 @@ export default function CabinetEditPage({ params }: CabinetEditPageProps) {
     }
     setMessage(null);
   }, [message]);
-
-  async function handleAddTag() {
-    if (!user || !canEdit || tagSaving) {
-      return;
-    }
-    const trimmed = tagInput.trim();
-    if (!trimmed) {
-      setTagError("標籤不可為空");
-      setTagMessage(null);
-      return;
-    }
-    if (tags.includes(trimmed)) {
-      setTagError("已有相同標籤");
-      setTagMessage(null);
-      return;
-    }
-    setTagSaving(true);
-    setTagError(null);
-    setTagMessage(null);
-    try {
-      const nextTags = normalizeCabinetTags([...tags, trimmed]);
-      const db = getFirebaseDb();
-      if (!db) {
-        setTagError("Firebase 尚未設定");
-        setTagSaving(false);
-        return;
-      }
-      const cabinetRef = doc(db, "cabinet", cabinetId);
-      await updateDoc(cabinetRef, {
-        tags: nextTags,
-        updatedAt: serverTimestamp(),
-      });
-      setTags(nextTags);
-      setTagInput("");
-      setTagMessage("已新增標籤");
-    } catch (err) {
-      console.error("新增標籤失敗", err);
-      setTagError("新增標籤時發生錯誤");
-    } finally {
-      setTagSaving(false);
-    }
-  }
-
-  async function handleRenameTag(target: string) {
-    if (!user || !canEdit || tagSaving) {
-      return;
-    }
-    const trimmed = editingValue.trim();
-    if (!trimmed) {
-      setTagError("標籤不可為空");
-      setTagMessage(null);
-      return;
-    }
-    if (trimmed !== target && tags.includes(trimmed)) {
-      setTagError("已有相同標籤");
-      setTagMessage(null);
-      return;
-    }
-    const db = getFirebaseDb();
-    if (!db) {
-      setTagError("Firebase 尚未設定");
-      return;
-    }
-    setTagSaving(true);
-    setTagError(null);
-    setTagMessage(null);
-    try {
-      const nextTags = normalizeCabinetTags([
-        ...tags.filter((tag) => tag !== target),
-        trimmed,
-      ]);
-      const cabinetRef = doc(db, "cabinet", cabinetId);
-      await updateDoc(cabinetRef, {
-        tags: nextTags,
-        updatedAt: serverTimestamp(),
-      });
-      if (trimmed !== target) {
-        const itemQuery = query(
-          collection(db, "item"),
-          where("uid", "==", user.uid),
-          where("cabinetId", "==", cabinetId),
-          where("tags", "array-contains", target)
-        );
-        const snap = await getDocs(itemQuery);
-        if (!snap.empty) {
-          const batch = writeBatch(db);
-          snap.forEach((docSnap) => {
-            const data = docSnap.data();
-            const sourceTags = Array.isArray(data?.tags)
-              ? data.tags
-                  .map((tag: unknown) => String(tag ?? "").trim())
-                  .filter((tag: string) => tag.length > 0)
-              : [];
-            const updatedTags = Array.from(
-              new Set(
-                sourceTags.map((tag) => (tag === target ? trimmed : tag))
-              )
-            );
-            batch.update(doc(db, "item", docSnap.id), { tags: updatedTags });
-          });
-          await batch.commit();
-        }
-      }
-      setTags(nextTags);
-      setEditingTag(null);
-      setEditingValue("");
-      setTagMessage("已更新標籤");
-    } catch (err) {
-      console.error("更新標籤失敗", err);
-      setTagError("更新標籤時發生錯誤");
-    } finally {
-      setTagSaving(false);
-    }
-  }
-
-  async function handleDeleteTag(target: string) {
-    if (!user || !canEdit || tagSaving) {
-      return;
-    }
-    if (!window.confirm(`確認刪除標籤「${target}」？`)) {
-      return;
-    }
-    const db = getFirebaseDb();
-    if (!db) {
-      setTagError("Firebase 尚未設定");
-      return;
-    }
-    setTagSaving(true);
-    setTagError(null);
-    setTagMessage(null);
-    try {
-      const nextTags = tags.filter((tag) => tag !== target);
-      const cabinetRef = doc(db, "cabinet", cabinetId);
-      await updateDoc(cabinetRef, {
-        tags: nextTags,
-        updatedAt: serverTimestamp(),
-      });
-      const itemQuery = query(
-        collection(db, "item"),
-        where("uid", "==", user.uid),
-        where("cabinetId", "==", cabinetId),
-        where("tags", "array-contains", target)
-      );
-      const snap = await getDocs(itemQuery);
-      if (!snap.empty) {
-        const batch = writeBatch(db);
-        snap.forEach((docSnap) => {
-          const data = docSnap.data();
-          const sourceTags = Array.isArray(data?.tags)
-            ? data.tags
-                .map((tag: unknown) => String(tag ?? "").trim())
-                .filter((tag: string) => tag.length > 0)
-            : [];
-          const updatedTags = sourceTags.filter((tag) => tag !== target);
-          batch.update(doc(db, "item", docSnap.id), { tags: updatedTags });
-        });
-        await batch.commit();
-      }
-      setTags(nextTags);
-      if (editingTag === target) {
-        setEditingTag(null);
-        setEditingValue("");
-      }
-      setTagMessage("已刪除標籤");
-    } catch (err) {
-      console.error("刪除標籤失敗", err);
-      setTagError("刪除標籤時發生錯誤");
-    } finally {
-      setTagSaving(false);
-    }
-  }
 
   const inputClass =
     "h-12 w-full rounded-xl border border-gray-200 bg-white px-4 text-base text-gray-900 shadow-sm focus:border-gray-300 focus:outline-none";
@@ -502,121 +290,6 @@ export default function CabinetEditPage({ params }: CabinetEditPageProps) {
             </button>
           </form>
         ) : null}
-
-        {!loading && canEdit && (
-          <section
-            id="tag-manager"
-            className="space-y-4 rounded-2xl border bg-white/70 p-6 shadow-sm"
-          >
-            <div className="space-y-1">
-              <h2 className="text-lg font-semibold text-gray-900">標籤管理</h2>
-              <p className="text-sm text-gray-500">
-                建立共享標籤後，物件編輯頁面即可直接勾選使用，也可在此重新命名或刪除。
-              </p>
-            </div>
-            {tagError && (
-              <div className="rounded-xl bg-red-50 px-4 py-3 text-xs text-red-700">
-                {tagError}
-              </div>
-            )}
-            {tagMessage && (
-              <div className="rounded-xl bg-emerald-50 px-4 py-3 text-xs text-emerald-700">
-                {tagMessage}
-              </div>
-            )}
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-              <input
-                value={tagInput}
-                onChange={(event) => setTagInput(event.target.value)}
-                placeholder="輸入新標籤，例如：漫畫、輕小說"
-                className="h-11 w-full rounded-xl border border-gray-200 bg-white px-4 text-sm text-gray-900 shadow-sm focus:border-gray-300 focus:outline-none"
-              />
-              <button
-                type="button"
-                onClick={handleAddTag}
-                disabled={tagSaving}
-                className="h-11 rounded-xl bg-blue-600 px-4 text-sm font-medium text-white shadow-sm transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
-              >
-                {tagSaving ? "處理中…" : "新增標籤"}
-              </button>
-            </div>
-            {tags.length === 0 ? (
-              <p className="rounded-xl border border-dashed border-gray-200 bg-white/70 px-4 py-6 text-center text-sm text-gray-500">
-                目前尚未建立任何標籤。
-              </p>
-            ) : (
-              <ul className="space-y-3">
-                {tags.map((tag) => {
-                  const isEditing = editingTag === tag;
-                  return (
-                    <li
-                      key={tag}
-                      className="rounded-xl border border-gray-100 bg-white px-4 py-3 text-sm text-gray-700 shadow-sm"
-                    >
-                      {isEditing ? (
-                        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                          <input
-                            value={editingValue}
-                            onChange={(event) => setEditingValue(event.target.value)}
-                            className="h-11 w-full rounded-xl border border-gray-200 bg-white px-4 text-sm text-gray-900 shadow-sm focus:border-gray-300 focus:outline-none"
-                          />
-                          <div className="flex gap-2">
-                            <button
-                              type="button"
-                              onClick={() => handleRenameTag(tag)}
-                              disabled={tagSaving}
-                              className="rounded-full bg-blue-600 px-4 py-2 text-xs font-medium text-white shadow-sm transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
-                            >
-                              儲存
-                            </button>
-                            <button
-                              type="button"
-                              onClick={() => {
-                                setEditingTag(null);
-                                setEditingValue("");
-                              }}
-                              disabled={tagSaving}
-                              className="rounded-full border border-gray-200 px-4 py-2 text-xs text-gray-600 transition hover:border-gray-300 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-70"
-                            >
-                              取消
-                            </button>
-                          </div>
-                        </div>
-                      ) : (
-                        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                          <span className="text-sm font-medium text-gray-900">#{tag}</span>
-                          <div className="flex gap-2">
-                            <button
-                              type="button"
-                              onClick={() => {
-                                setEditingTag(tag);
-                                setEditingValue(tag);
-                                setTagError(null);
-                                setTagMessage(null);
-                              }}
-                              disabled={tagSaving}
-                              className="rounded-full border border-gray-200 px-4 py-2 text-xs text-gray-600 transition hover:border-gray-300 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-70"
-                            >
-                              重新命名
-                            </button>
-                            <button
-                              type="button"
-                              onClick={() => handleDeleteTag(tag)}
-                              disabled={tagSaving}
-                              className="rounded-full border border-red-200 px-4 py-2 text-xs text-red-600 transition hover:border-red-300 hover:text-red-700 disabled:cursor-not-allowed disabled:opacity-70"
-                            >
-                              刪除
-                            </button>
-                          </div>
-                        </div>
-                      )}
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-          </section>
-        )}
 
         {!loading && canEdit && (
           <section className="space-y-4 rounded-2xl border border-red-200 bg-red-50/70 p-6 shadow-sm">

--- a/src/app/cabinet/[id]/page.tsx
+++ b/src/app/cabinet/[id]/page.tsx
@@ -574,7 +574,7 @@ export default function CabinetDetailPage({ params }: CabinetPageProps) {
     return (
       <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
         <div className="mx-auto flex w-full max-w-2xl flex-col gap-4 rounded-2xl border bg-white/70 p-6 shadow-sm">
-          <h1 className="text-2xl font-semibold text-gray-900">櫃子內容</h1>
+          <h1 className="break-anywhere text-2xl font-semibold text-gray-900">櫃子內容</h1>
           <p className="text-base text-gray-600">
             未登入。請先前往
             <Link href="/login" className="ml-1 underline">
@@ -605,8 +605,8 @@ export default function CabinetDetailPage({ params }: CabinetPageProps) {
     return (
       <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
         <div className="mx-auto flex w-full max-w-2xl flex-col gap-4 rounded-2xl border bg-white/70 p-6 shadow-sm">
-          <h1 className="text-2xl font-semibold text-gray-900">櫃子內容</h1>
-          <div className="rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">
+          <h1 className="break-anywhere text-2xl font-semibold text-gray-900">櫃子內容</h1>
+          <div className="break-anywhere rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">
             {cabinetError}
           </div>
           <div className="flex flex-col gap-2 sm:flex-row">
@@ -624,9 +624,9 @@ export default function CabinetDetailPage({ params }: CabinetPageProps) {
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-8">
         <header className="flex flex-col gap-4 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
           <div className="space-y-1">
-            <h1 className="text-2xl font-semibold text-gray-900">{cabinetName}</h1>
+            <h1 className="break-anywhere text-2xl font-semibold text-gray-900">{cabinetName}</h1>
             {cabinetNote && (
-              <p className="text-sm text-gray-600">{cabinetNote}</p>
+              <p className="break-anywhere text-sm text-gray-600">{cabinetNote}</p>
             )}
           </div>
           <div className="flex flex-col gap-2 text-sm sm:flex-row sm:flex-wrap">
@@ -884,7 +884,7 @@ export default function CabinetDetailPage({ params }: CabinetPageProps) {
         </section>
 
         {listError && (
-          <div className="rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">
+          <div className="break-anywhere rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">
             {listError}
           </div>
         )}

--- a/src/app/cabinet/[id]/page.tsx
+++ b/src/app/cabinet/[id]/page.tsx
@@ -27,6 +27,7 @@ import {
   type ItemStatus,
   type UpdateFrequency,
 } from "@/lib/types";
+import { normalizeThumbTransform } from "@/lib/image-utils";
 
 type CabinetPageProps = {
   params: Promise<{ id: string }>;
@@ -293,6 +294,9 @@ export default function CabinetDetailPage({ params }: CabinetPageProps) {
             tags,
             links,
             thumbUrl: typeof data.thumbUrl === "string" ? data.thumbUrl : null,
+            thumbTransform: data.thumbTransform
+              ? normalizeThumbTransform(data.thumbTransform)
+              : null,
             progressNote:
               typeof data.progressNote === "string" ? data.progressNote : null,
             insightNote:

--- a/src/app/cabinet/[id]/page.tsx
+++ b/src/app/cabinet/[id]/page.tsx
@@ -133,6 +133,7 @@ export default function CabinetDetailPage({ params }: CabinetPageProps) {
   const [cabinetLoading, setCabinetLoading] = useState(true);
   const [cabinetError, setCabinetError] = useState<string | null>(null);
   const [canView, setCanView] = useState(false);
+  const [cabinetNote, setCabinetNote] = useState<string | null>(null);
   const [items, setItems] = useState<ItemRecord[]>([]);
   const [itemsLoading, setItemsLoading] = useState(true);
   const [listError, setListError] = useState<string | null>(null);
@@ -167,6 +168,7 @@ export default function CabinetDetailPage({ params }: CabinetPageProps) {
       setCabinetName("");
       setCabinetError(null);
       setCanView(false);
+      setCabinetNote(null);
       setCabinetLoading(false);
       setCabinetTags([]);
       return;
@@ -175,10 +177,12 @@ export default function CabinetDetailPage({ params }: CabinetPageProps) {
     setCabinetLoading(true);
     setCabinetError(null);
     setCanView(false);
+    setCabinetNote(null);
     const db = getFirebaseDb();
     if (!db) {
       setCabinetError("Firebase 尚未設定");
       setCabinetLoading(false);
+      setCabinetNote(null);
       setCabinetTags([]);
       return;
     }
@@ -188,6 +192,7 @@ export default function CabinetDetailPage({ params }: CabinetPageProps) {
         if (!active) return;
         if (!snap.exists()) {
           setCabinetError("找不到櫃子");
+          setCabinetNote(null);
           setCabinetLoading(false);
           setCabinetTags([]);
           return;
@@ -195,19 +200,26 @@ export default function CabinetDetailPage({ params }: CabinetPageProps) {
         const data = snap.data();
         if (data?.uid !== user.uid) {
           setCabinetError("您沒有存取此櫃子的權限");
+          setCabinetNote(null);
           setCabinetLoading(false);
           setCabinetTags([]);
           return;
         }
         const name = typeof data?.name === "string" && data.name ? data.name : "未命名櫃子";
+        const note =
+          typeof data?.note === "string" && data.note.trim().length > 0
+            ? data.note.trim()
+            : null;
         setCabinetName(name);
         setCanView(true);
+        setCabinetNote(note);
         setCabinetTags(normalizeCabinetTags(data?.tags));
         setCabinetLoading(false);
       })
       .catch(() => {
         if (!active) return;
         setCabinetError("載入櫃子資訊時發生錯誤");
+        setCabinetNote(null);
         setCabinetLoading(false);
         setCabinetTags([]);
       });
@@ -593,7 +605,12 @@ export default function CabinetDetailPage({ params }: CabinetPageProps) {
     <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-8">
         <header className="flex flex-col gap-4 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
-          <h1 className="text-2xl font-semibold text-gray-900">{cabinetName}</h1>
+          <div className="space-y-1">
+            <h1 className="text-2xl font-semibold text-gray-900">{cabinetName}</h1>
+            {cabinetNote && (
+              <p className="text-sm text-gray-600">{cabinetNote}</p>
+            )}
+          </div>
           <div className="flex flex-col gap-2 text-sm sm:flex-row sm:flex-wrap">
             <Link href="/cabinets" className={`${buttonClass({ variant: "secondary" })} w-full sm:w-auto`}>
               返回櫃子列表

--- a/src/app/cabinet/[id]/tags/page.tsx
+++ b/src/app/cabinet/[id]/tags/page.tsx
@@ -385,10 +385,10 @@ export default function CabinetTagManagerPage({ params }: CabinetTagPageProps) {
               </div>
 
               {tagError && (
-                <div className="rounded-xl bg-red-50 px-4 py-3 text-xs text-red-700">{tagError}</div>
+                <div className="break-anywhere rounded-xl bg-red-50 px-4 py-3 text-xs text-red-700">{tagError}</div>
               )}
               {tagMessage && (
-                <div className="rounded-xl bg-emerald-50 px-4 py-3 text-xs text-emerald-700">{tagMessage}</div>
+                <div className="break-anywhere rounded-xl bg-emerald-50 px-4 py-3 text-xs text-emerald-700">{tagMessage}</div>
               )}
 
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
@@ -419,16 +419,16 @@ export default function CabinetTagManagerPage({ params }: CabinetTagPageProps) {
                     return (
                       <li
                         key={tag}
-                        className="rounded-xl border border-gray-100 bg-white px-4 py-3 text-sm text-gray-700 shadow-sm"
+                        className="min-w-0 overflow-hidden rounded-xl border border-gray-100 bg-white px-4 py-3 text-sm text-gray-700 shadow-sm"
                       >
                         {isEditing ? (
-                          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                          <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:gap-3">
                             <input
                               value={editingValue}
                               onChange={(event) => setEditingValue(event.target.value)}
-                              className={inputClass}
+                              className={`${inputClass} sm:min-w-0 sm:flex-1`}
                             />
-                            <div className="flex gap-2">
+                            <div className="flex flex-wrap gap-2 sm:flex-nowrap">
                               <button
                                 type="button"
                                 onClick={() => handleRenameTag(tag)}
@@ -451,9 +451,9 @@ export default function CabinetTagManagerPage({ params }: CabinetTagPageProps) {
                             </div>
                           </div>
                         ) : (
-                          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                            <span className="text-sm font-medium text-gray-900">#{tag}</span>
-                            <div className="flex gap-2">
+                          <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:gap-3 sm:min-w-0">
+                            <span className="break-anywhere text-sm font-medium text-gray-900 sm:min-w-0 sm:flex-1">#{tag}</span>
+                            <div className="flex flex-wrap gap-2 sm:flex-nowrap sm:justify-end">
                               <button
                                 type="button"
                                 onClick={() => {

--- a/src/app/cabinet/[id]/tags/page.tsx
+++ b/src/app/cabinet/[id]/tags/page.tsx
@@ -1,0 +1,492 @@
+"use client";
+
+import Link from "next/link";
+import { use, useEffect, useState } from "react";
+import { onAuthStateChanged, type User } from "firebase/auth";
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  query,
+  serverTimestamp,
+  updateDoc,
+  where,
+  writeBatch,
+} from "firebase/firestore";
+
+import { getFirebaseAuth, getFirebaseDb } from "@/lib/firebase";
+
+type CabinetTagPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+function normalizeCabinetTags(input: unknown): string[] {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+  return Array.from(
+    new Set(
+      input
+        .map((tag) => String(tag ?? "").trim())
+        .filter((tag): tag is string => tag.length > 0)
+    )
+  ).sort((a, b) => a.localeCompare(b, "zh-Hant"));
+}
+
+export default function CabinetTagManagerPage({ params }: CabinetTagPageProps) {
+  const { id: cabinetId } = use(params);
+  const [user, setUser] = useState<User | null>(null);
+  const [authChecked, setAuthChecked] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [canEdit, setCanEdit] = useState(false);
+  const [cabinetName, setCabinetName] = useState<string>("");
+  const [error, setError] = useState<string | null>(null);
+  const [tags, setTags] = useState<string[]>([]);
+  const [tagInput, setTagInput] = useState("");
+  const [tagError, setTagError] = useState<string | null>(null);
+  const [tagMessage, setTagMessage] = useState<string | null>(null);
+  const [tagSaving, setTagSaving] = useState(false);
+  const [editingTag, setEditingTag] = useState<string | null>(null);
+  const [editingValue, setEditingValue] = useState("");
+
+  useEffect(() => {
+    const auth = getFirebaseAuth();
+    if (!auth) {
+      setAuthChecked(true);
+      setLoading(false);
+      setError("Firebase 尚未設定");
+      return undefined;
+    }
+    const unsub = onAuthStateChanged(auth, (current) => {
+      setUser(current);
+      setAuthChecked(true);
+    });
+    return () => unsub();
+  }, []);
+
+  useEffect(() => {
+    if (!user) {
+      setLoading(false);
+      setCanEdit(false);
+      setCabinetName("");
+      setTags([]);
+      setTagInput("");
+      setTagMessage(null);
+      setTagError(null);
+      setEditingTag(null);
+      setEditingValue("");
+      setError(null);
+      return;
+    }
+    let active = true;
+    setLoading(true);
+    setError(null);
+    setTagError(null);
+    setTagMessage(null);
+    const db = getFirebaseDb();
+    if (!db) {
+      setError("Firebase 尚未設定");
+      setCanEdit(false);
+      setLoading(false);
+      setTags([]);
+      return;
+    }
+    const cabinetRef = doc(db, "cabinet", cabinetId);
+    getDoc(cabinetRef)
+      .then((snap) => {
+        if (!active) return;
+        if (!snap.exists()) {
+          setError("找不到櫃子");
+          setCanEdit(false);
+          setLoading(false);
+          setCabinetName("");
+          setTags([]);
+          return;
+        }
+        const data = snap.data();
+        if (data?.uid !== user.uid) {
+          setError("您沒有存取此櫃子的權限");
+          setCanEdit(false);
+          setLoading(false);
+          setCabinetName("");
+          setTags([]);
+          return;
+        }
+        const nameValue =
+          typeof data?.name === "string" && data.name.trim().length > 0
+            ? data.name.trim()
+            : "未命名櫃子";
+        setCabinetName(nameValue);
+        setTags(normalizeCabinetTags(data?.tags));
+        setCanEdit(true);
+        setLoading(false);
+      })
+      .catch(() => {
+        if (!active) return;
+        setError("載入櫃子資料時發生錯誤");
+        setCanEdit(false);
+        setLoading(false);
+        setCabinetName("");
+        setTags([]);
+      });
+    return () => {
+      active = false;
+    };
+  }, [user, cabinetId]);
+
+  async function handleAddTag() {
+    if (!user || !canEdit || tagSaving) {
+      return;
+    }
+    const trimmed = tagInput.trim();
+    if (!trimmed) {
+      setTagError("標籤不可為空");
+      setTagMessage(null);
+      return;
+    }
+    if (tags.includes(trimmed)) {
+      setTagError("已有相同標籤");
+      setTagMessage(null);
+      return;
+    }
+    setTagSaving(true);
+    setTagError(null);
+    setTagMessage(null);
+    try {
+      const nextTags = normalizeCabinetTags([...tags, trimmed]);
+      const db = getFirebaseDb();
+      if (!db) {
+        setTagError("Firebase 尚未設定");
+        setTagSaving(false);
+        return;
+      }
+      const cabinetRef = doc(db, "cabinet", cabinetId);
+      await updateDoc(cabinetRef, {
+        tags: nextTags,
+        updatedAt: serverTimestamp(),
+      });
+      setTags(nextTags);
+      setTagInput("");
+      setTagMessage("已新增標籤");
+    } catch (err) {
+      console.error("新增標籤失敗", err);
+      setTagError("新增標籤時發生錯誤");
+    } finally {
+      setTagSaving(false);
+    }
+  }
+
+  async function handleRenameTag(target: string) {
+    if (!user || !canEdit || tagSaving) {
+      return;
+    }
+    const trimmed = editingValue.trim();
+    if (!trimmed) {
+      setTagError("標籤不可為空");
+      setTagMessage(null);
+      return;
+    }
+    if (trimmed !== target && tags.includes(trimmed)) {
+      setTagError("已有相同標籤");
+      setTagMessage(null);
+      return;
+    }
+    const db = getFirebaseDb();
+    if (!db) {
+      setTagError("Firebase 尚未設定");
+      return;
+    }
+    setTagSaving(true);
+    setTagError(null);
+    setTagMessage(null);
+    try {
+      const nextTags = normalizeCabinetTags([
+        ...tags.filter((tag) => tag !== target),
+        trimmed,
+      ]);
+      const cabinetRef = doc(db, "cabinet", cabinetId);
+      await updateDoc(cabinetRef, {
+        tags: nextTags,
+        updatedAt: serverTimestamp(),
+      });
+      if (trimmed !== target) {
+        const itemQuery = query(
+          collection(db, "item"),
+          where("uid", "==", user.uid),
+          where("cabinetId", "==", cabinetId),
+          where("tags", "array-contains", target)
+        );
+        const snap = await getDocs(itemQuery);
+        if (!snap.empty) {
+          const batch = writeBatch(db);
+          snap.forEach((docSnap) => {
+            const data = docSnap.data();
+            const sourceTags = Array.isArray(data?.tags)
+              ? data.tags
+                  .map((tag: unknown) => String(tag ?? "").trim())
+                  .filter((tag: string) => tag.length > 0)
+              : [];
+            const updatedTags = Array.from(
+              new Set(
+                sourceTags.map((tag) => (tag === target ? trimmed : tag))
+              )
+            );
+            batch.update(doc(db, "item", docSnap.id), { tags: updatedTags });
+          });
+          await batch.commit();
+        }
+      }
+      setTags(nextTags);
+      setEditingTag(null);
+      setEditingValue("");
+      setTagMessage("已更新標籤");
+    } catch (err) {
+      console.error("更新標籤失敗", err);
+      setTagError("更新標籤時發生錯誤");
+    } finally {
+      setTagSaving(false);
+    }
+  }
+
+  async function handleDeleteTag(target: string) {
+    if (!user || !canEdit || tagSaving) {
+      return;
+    }
+    if (!window.confirm(`確認刪除標籤「${target}」？`)) {
+      return;
+    }
+    const db = getFirebaseDb();
+    if (!db) {
+      setTagError("Firebase 尚未設定");
+      return;
+    }
+    setTagSaving(true);
+    setTagError(null);
+    setTagMessage(null);
+    try {
+      const nextTags = tags.filter((tag) => tag !== target);
+      const cabinetRef = doc(db, "cabinet", cabinetId);
+      await updateDoc(cabinetRef, {
+        tags: nextTags,
+        updatedAt: serverTimestamp(),
+      });
+      const itemQuery = query(
+        collection(db, "item"),
+        where("uid", "==", user.uid),
+        where("cabinetId", "==", cabinetId),
+        where("tags", "array-contains", target)
+      );
+      const snap = await getDocs(itemQuery);
+      if (!snap.empty) {
+        const batch = writeBatch(db);
+        snap.forEach((docSnap) => {
+          const data = docSnap.data();
+          const sourceTags = Array.isArray(data?.tags)
+            ? data.tags
+                .map((tag: unknown) => String(tag ?? "").trim())
+                .filter((tag: string) => tag.length > 0)
+            : [];
+          const updatedTags = sourceTags.filter((tag) => tag !== target);
+          batch.update(doc(db, "item", docSnap.id), { tags: updatedTags });
+        });
+        await batch.commit();
+      }
+      setTags(nextTags);
+      if (editingTag === target) {
+        setEditingTag(null);
+        setEditingValue("");
+      }
+      setTagMessage("已刪除標籤");
+    } catch (err) {
+      console.error("刪除標籤失敗", err);
+      setTagError("刪除標籤時發生錯誤");
+    } finally {
+      setTagSaving(false);
+    }
+  }
+
+  const inputClass =
+    "h-11 w-full rounded-xl border border-gray-200 bg-white px-4 text-sm text-gray-900 shadow-sm focus:border-gray-300 focus:outline-none";
+
+  if (!authChecked) {
+    return (
+      <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+        <div className="mx-auto w-full max-w-2xl rounded-2xl border bg-white/70 p-6 text-base shadow-sm">
+          正在確認登入狀態…
+        </div>
+      </main>
+    );
+  }
+
+  if (!user) {
+    return (
+      <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+        <div className="mx-auto flex w-full max-w-2xl flex-col gap-4 rounded-2xl border bg-white/70 p-6 shadow-sm">
+          <h1 className="text-2xl font-semibold text-gray-900">櫃子標籤管理</h1>
+          <p className="text-base text-gray-600">
+            未登入。請前往
+            <Link href="/login" className="ml-1 underline">
+              /login
+            </Link>
+            以管理標籤，或回到
+            <Link href="/" className="ml-1 underline">
+              首頁
+            </Link>
+            了解更多功能。
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  const encodedId = encodeURIComponent(cabinetId);
+
+  return (
+    <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-8">
+        <header className="flex flex-col gap-4 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
+          <div className="space-y-1">
+            <h1 className="text-2xl font-semibold text-gray-900">櫃子標籤管理</h1>
+            <p className="text-sm text-gray-500">管理 {cabinetName} 的共享標籤。</p>
+          </div>
+          <div className="flex flex-col gap-2 text-sm sm:flex-row sm:flex-wrap">
+            <Link
+              href={`/cabinet/${encodedId}`}
+              className="w-full rounded-xl border border-gray-200 bg-white px-4 py-2 text-center text-sm text-gray-700 shadow-sm transition hover:border-gray-300 sm:w-auto"
+            >
+              返回櫃子內容
+            </Link>
+            <Link
+              href={`/cabinet/${encodedId}/edit`}
+              className="w-full rounded-xl border border-gray-200 bg-white px-4 py-2 text-center text-sm text-gray-700 shadow-sm transition hover:border-gray-300 sm:w-auto"
+            >
+              編輯櫃子
+            </Link>
+          </div>
+        </header>
+
+        <section className="space-y-4 rounded-2xl border bg-white/70 p-6 shadow-sm">
+          {loading ? (
+            <p className="text-sm text-gray-500">載入標籤中…</p>
+          ) : error ? (
+            <div className="rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+          ) : !canEdit ? (
+            <div className="rounded-xl bg-amber-50 px-4 py-3 text-sm text-amber-700">
+              您沒有管理此櫃子標籤的權限。
+            </div>
+          ) : (
+            <>
+              <div className="space-y-1">
+                <h2 className="text-lg font-semibold text-gray-900">標籤管理</h2>
+                <p className="text-sm text-gray-500">
+                  建立共享標籤後，物件編輯頁面即可直接勾選使用，也可在此重新命名或刪除。
+                </p>
+              </div>
+
+              {tagError && (
+                <div className="rounded-xl bg-red-50 px-4 py-3 text-xs text-red-700">{tagError}</div>
+              )}
+              {tagMessage && (
+                <div className="rounded-xl bg-emerald-50 px-4 py-3 text-xs text-emerald-700">{tagMessage}</div>
+              )}
+
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                <input
+                  value={tagInput}
+                  onChange={(event) => setTagInput(event.target.value)}
+                  placeholder="輸入新標籤，例如：漫畫、輕小說"
+                  className={inputClass}
+                />
+                <button
+                  type="button"
+                  onClick={handleAddTag}
+                  disabled={tagSaving}
+                  className="h-11 rounded-xl bg-blue-600 px-4 text-sm font-medium text-white shadow-sm transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+                >
+                  {tagSaving ? "處理中…" : "新增標籤"}
+                </button>
+              </div>
+
+              {tags.length === 0 ? (
+                <p className="rounded-xl border border-dashed border-gray-200 bg-white/70 px-4 py-6 text-center text-sm text-gray-500">
+                  目前尚未建立任何標籤。
+                </p>
+              ) : (
+                <ul className="space-y-3">
+                  {tags.map((tag) => {
+                    const isEditing = editingTag === tag;
+                    return (
+                      <li
+                        key={tag}
+                        className="rounded-xl border border-gray-100 bg-white px-4 py-3 text-sm text-gray-700 shadow-sm"
+                      >
+                        {isEditing ? (
+                          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                            <input
+                              value={editingValue}
+                              onChange={(event) => setEditingValue(event.target.value)}
+                              className={inputClass}
+                            />
+                            <div className="flex gap-2">
+                              <button
+                                type="button"
+                                onClick={() => handleRenameTag(tag)}
+                                disabled={tagSaving}
+                                className="rounded-full bg-blue-600 px-4 py-2 text-xs font-medium text-white shadow-sm transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+                              >
+                                儲存
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  setEditingTag(null);
+                                  setEditingValue("");
+                                }}
+                                disabled={tagSaving}
+                                className="rounded-full border border-gray-200 px-4 py-2 text-xs text-gray-600 transition hover:border-gray-300 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-70"
+                              >
+                                取消
+                              </button>
+                            </div>
+                          </div>
+                        ) : (
+                          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                            <span className="text-sm font-medium text-gray-900">#{tag}</span>
+                            <div className="flex gap-2">
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  setEditingTag(tag);
+                                  setEditingValue(tag);
+                                  setTagError(null);
+                                  setTagMessage(null);
+                                }}
+                                disabled={tagSaving}
+                                className="rounded-full border border-gray-200 px-4 py-2 text-xs text-gray-600 transition hover:border-gray-300 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-70"
+                              >
+                                重新命名
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => handleDeleteTag(tag)}
+                                disabled={tagSaving}
+                                className="rounded-full border border-red-200 px-4 py-2 text-xs text-red-600 transition hover:border-red-300 hover:text-red-700 disabled:cursor-not-allowed disabled:opacity-70"
+                              >
+                                刪除
+                              </button>
+                            </div>
+                          </div>
+                        )}
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </>
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/cabinets/page.tsx
+++ b/src/app/cabinets/page.tsx
@@ -170,8 +170,8 @@ export default function CabinetsPage() {
     if (!feedback) return null;
     const baseClass =
       feedback.type === "error"
-        ? "rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700"
-        : "rounded-xl bg-emerald-50 px-4 py-3 text-sm text-emerald-700";
+        ? "break-anywhere rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700"
+        : "break-anywhere rounded-xl bg-emerald-50 px-4 py-3 text-sm text-emerald-700";
     return <div className={baseClass}>{feedback.message}</div>;
   }, [feedback]);
 
@@ -347,12 +347,12 @@ export default function CabinetsPage() {
                       <div className="space-y-1">
                         <Link
                           href={`/cabinet/${encodedId}`}
-                          className="text-lg font-semibold text-gray-900 underline-offset-4 hover:underline"
+                          className="break-anywhere text-lg font-semibold text-gray-900 underline-offset-4 hover:underline"
                         >
                           {displayName}
                         </Link>
                         {row.note && (
-                          <p className="text-sm text-gray-600">{row.note}</p>
+                          <p className="break-anywhere text-sm text-gray-600">{row.note}</p>
                         )}
                       </div>
                       <div className="flex flex-col gap-2 text-sm sm:flex-row sm:flex-wrap">
@@ -392,7 +392,7 @@ export default function CabinetsPage() {
               </p>
             </div>
             {reorderError && (
-              <div className="rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">
+              <div className="break-anywhere rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">
                 {reorderError}
               </div>
             )}
@@ -408,17 +408,17 @@ export default function CabinetsPage() {
                         <button
                           type="button"
                           onClick={() => setSelectedId(cabinet.id)}
-                          className={`w-full rounded-xl border px-4 py-3 text-left text-sm shadow-sm transition ${
+                          className={`w-full overflow-hidden rounded-xl border px-4 py-3 text-left text-sm shadow-sm transition ${
                             isSelected
                               ? "border-blue-400 bg-white"
                               : "border-gray-200 bg-white/80 hover:border-blue-200"
                           }`}
                         >
-                          <span className="font-medium text-gray-900">
+                          <span className="break-anywhere font-medium text-gray-900">
                             {cabinet.name || "未命名櫃子"}
                           </span>
                           {cabinet.note && (
-                            <span className="mt-1 block text-xs text-gray-500">
+                            <span className="break-anywhere mt-1 block text-xs text-gray-500">
                               {cabinet.note}
                             </span>
                           )}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -34,4 +34,9 @@ body {
     text-overflow: ellipsis;
     word-break: break-word;
   }
+
+  .break-anywhere {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,14 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+@layer utilities {
+  .line-clamp-2 {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    word-break: break-word;
+  }
+}

--- a/src/app/item/[id]/page.tsx
+++ b/src/app/item/[id]/page.tsx
@@ -765,32 +765,42 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
               <p className="text-sm text-gray-500">依編輯順序列出重要角色、地點或其他物件。</p>
             </div>
             <div className="space-y-4">
-              {appearances.map((entry, index) => (
-                <div
-                  key={`${entry.name}-${index}`}
-                  className="flex gap-4 rounded-2xl border bg-white/80 p-4 shadow-sm"
-                >
-                  {entry.thumbUrl ? (
-                    <div className="relative aspect-square w-20 shrink-0 overflow-hidden rounded-lg border bg-white">
-                      {/* eslint-disable-next-line @next/next/no-img-element */}
-                      <img
-                        src={entry.thumbUrl}
-                        alt={`${entry.name} 縮圖`}
-                        className="h-full w-full object-cover"
-                        loading="lazy"
-                      />
-                    </div>
-                  ) : null}
-                  <div className="flex-1 space-y-2">
-                    <div className="text-base font-medium text-gray-900">{entry.name}</div>
-                    {entry.note && (
-                      <div className="whitespace-pre-wrap break-words text-sm text-gray-700">
-                        {entry.note}
+              {appearances.map((entry, index) => {
+                const appearanceTransform =
+                  entry.thumbTransform ?? DEFAULT_THUMB_TRANSFORM;
+                const appearanceStyle = {
+                  transform: `translate(${appearanceTransform.offsetX}%, ${appearanceTransform.offsetY}%) scale(${appearanceTransform.scale})`,
+                  transformOrigin: "center" as const,
+                };
+                return (
+                  <div
+                    key={`${entry.name}-${index}`}
+                    className="flex gap-4 rounded-2xl border bg-white/80 p-4 shadow-sm"
+                  >
+                    {entry.thumbUrl ? (
+                      <div className="relative aspect-square w-20 shrink-0 overflow-hidden rounded-lg border bg-white">
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img
+                          src={entry.thumbUrl}
+                          alt={`${entry.name} 縮圖`}
+                          className="h-full w-full select-none object-cover"
+                          style={appearanceStyle}
+                          loading="lazy"
+                          draggable={false}
+                        />
                       </div>
-                    )}
+                    ) : null}
+                    <div className="flex-1 space-y-2">
+                      <div className="text-base font-medium text-gray-900">{entry.name}</div>
+                      {entry.note && (
+                        <div className="whitespace-pre-wrap break-words text-sm text-gray-700">
+                          {entry.note}
+                        </div>
+                      )}
+                    </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           </section>
         )}

--- a/src/app/item/[id]/page.tsx
+++ b/src/app/item/[id]/page.tsx
@@ -30,6 +30,7 @@ import {
   UPDATE_FREQUENCY_OPTIONS,
   UPDATE_FREQUENCY_VALUES,
 } from "@/lib/types";
+import { DEFAULT_THUMB_TRANSFORM, normalizeThumbTransform } from "@/lib/image-utils";
 
 const statusLabelMap = new Map(
   ITEM_STATUS_OPTIONS.map((option) => [option.value, option.label])
@@ -109,6 +110,20 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
   const [noteError, setNoteError] = useState<string | null>(null);
   const [noteFeedback, setNoteFeedback] = useState<NoteFeedback | null>(null);
   const noteTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const derivedThumbTransform = item?.thumbTransform ?? DEFAULT_THUMB_TRANSFORM;
+  const thumbStyle = useMemo(
+    () => ({
+      transform: `translate(${derivedThumbTransform.offsetX}%, ${derivedThumbTransform.offsetY}%) scale(${derivedThumbTransform.scale})`,
+      transformOrigin: "center",
+    }),
+    [
+      derivedThumbTransform.offsetX,
+      derivedThumbTransform.offsetY,
+      derivedThumbTransform.scale,
+    ]
+  );
+  const canUseOptimizedThumb = isOptimizedImageUrl(item?.thumbUrl);
 
   useEffect(() => {
     const auth = getFirebaseAuth();
@@ -223,6 +238,9 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
           tags,
           links,
           thumbUrl: typeof data.thumbUrl === "string" ? data.thumbUrl : null,
+          thumbTransform: data.thumbTransform
+            ? normalizeThumbTransform(data.thumbTransform)
+            : null,
           progressNote: typeof data.progressNote === "string" ? data.progressNote : null,
           insightNote: typeof data.insightNote === "string" ? data.insightNote : null,
           note: typeof data.note === "string" ? data.note : null,
@@ -504,7 +522,6 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
     );
   }
 
-  const canUseOptimizedThumb = isOptimizedImageUrl(item.thumbUrl);
   const statusLabel = statusLabelMap.get(item.status) ?? item.status;
   const ratingText =
     typeof item.rating === "number" && Number.isFinite(item.rating)
@@ -593,14 +610,18 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
                     fill
                     sizes="(min-width: 768px) 14rem, 100vw"
                     className="object-cover"
+                    style={thumbStyle}
+                    draggable={false}
                   />
                 ) : (
                   /* eslint-disable-next-line @next/next/no-img-element */
                   <img
                     src={item.thumbUrl}
                     alt={`${item.titleZh} 封面`}
-                    className="h-full w-full object-cover"
+                    className="h-full w-full select-none object-cover"
+                    style={thumbStyle}
                     loading="lazy"
+                    draggable={false}
                   />
                 )}
               </div>

--- a/src/app/item/quick-add/page.tsx
+++ b/src/app/item/quick-add/page.tsx
@@ -195,6 +195,7 @@ export default function QuickAddItemPage() {
         tags: [],
         links,
         thumbUrl: thumbUrl || null,
+        thumbTransform: null,
         progressNote: null,
         insightNote: null,
         note: null,

--- a/src/app/item/quick-add/page.tsx
+++ b/src/app/item/quick-add/page.tsx
@@ -90,13 +90,21 @@ export default function QuickAddItemPage() {
             const createdAt = data?.createdAt;
             const createdMs =
               createdAt instanceof Timestamp ? createdAt.toMillis() : 0;
+            const orderValue =
+              typeof data?.order === "number" ? data.order : createdMs;
             return {
               id: docSnap.id,
               name: (data?.name as string) ?? "",
               createdMs,
+              order: orderValue,
             };
           })
-          .sort((a, b) => b.createdMs - a.createdMs)
+          .sort((a, b) => {
+            if (a.order === b.order) {
+              return b.createdMs - a.createdMs;
+            }
+            return b.order - a.order;
+          })
           .map((item) => ({ id: item.id, name: item.name }));
         setCabinets(rows);
         setLoadingCabinets(false);

--- a/src/app/item/quick-add/page.tsx
+++ b/src/app/item/quick-add/page.tsx
@@ -267,7 +267,7 @@ export default function QuickAddItemPage() {
 
         <section className="space-y-4 rounded-2xl border bg-white/70 p-6 shadow-sm">
           {error && (
-            <div className="rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">
+            <div className="break-anywhere rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">
               {error}
             </div>
           )}

--- a/src/app/item/quick-add/page.tsx
+++ b/src/app/item/quick-add/page.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+import Link from "next/link";
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { onAuthStateChanged, type User } from "firebase/auth";
+import {
+  addDoc,
+  collection,
+  getDocs,
+  query,
+  serverTimestamp,
+  Timestamp,
+  where,
+} from "firebase/firestore";
+
+import { getFirebaseAuth, getFirebaseDb } from "@/lib/firebase";
+import { buttonClass } from "@/lib/ui";
+
+type CabinetOption = { id: string; name: string };
+
+type FormState = {
+  cabinetId: string;
+  titleZh: string;
+  sourceUrl: string;
+  thumbUrl: string;
+};
+
+function isValidHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+export default function QuickAddItemPage() {
+  const router = useRouter();
+  const [user, setUser] = useState<User | null>(null);
+  const [authChecked, setAuthChecked] = useState(false);
+  const [cabinets, setCabinets] = useState<CabinetOption[]>([]);
+  const [loadingCabinets, setLoadingCabinets] = useState(true);
+  const [form, setForm] = useState<FormState>({
+    cabinetId: "",
+    titleZh: "",
+    sourceUrl: "",
+    thumbUrl: "",
+  });
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const auth = getFirebaseAuth();
+    if (!auth) {
+      setAuthChecked(true);
+      setError("Firebase 尚未設定");
+      return undefined;
+    }
+
+    const unsub = onAuthStateChanged(auth, (current) => {
+      setUser(current);
+      setAuthChecked(true);
+    });
+    return () => unsub();
+  }, []);
+
+  useEffect(() => {
+    if (!user) {
+      setCabinets([]);
+      setLoadingCabinets(false);
+      return;
+    }
+    let active = true;
+    const db = getFirebaseDb();
+    if (!db) {
+      setError("Firebase 尚未設定");
+      setLoadingCabinets(false);
+      setCabinets([]);
+      return;
+    }
+    setLoadingCabinets(true);
+    const q = query(collection(db, "cabinet"), where("uid", "==", user.uid));
+    getDocs(q)
+      .then((snap) => {
+        if (!active) return;
+        const rows: CabinetOption[] = snap.docs
+          .map((docSnap) => {
+            const data = docSnap.data();
+            const createdAt = data?.createdAt;
+            const createdMs =
+              createdAt instanceof Timestamp ? createdAt.toMillis() : 0;
+            return {
+              id: docSnap.id,
+              name: (data?.name as string) ?? "",
+              createdMs,
+            };
+          })
+          .sort((a, b) => b.createdMs - a.createdMs)
+          .map((item) => ({ id: item.id, name: item.name }));
+        setCabinets(rows);
+        setLoadingCabinets(false);
+      })
+      .catch(() => {
+        if (!active) return;
+        setError("載入櫃子清單時發生錯誤");
+        setCabinets([]);
+        setLoadingCabinets(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [user]);
+
+  useEffect(() => {
+    if (!form.cabinetId && cabinets.length > 0) {
+      setForm((prev) => ({ ...prev, cabinetId: cabinets[0].id }));
+    }
+  }, [cabinets, form.cabinetId]);
+
+  const hasCabinet = cabinets.length > 0;
+
+  const submitDisabled = useMemo(() => {
+    if (!hasCabinet) return true;
+    if (saving) return true;
+    return !form.titleZh.trim();
+  }, [form.titleZh, hasCabinet, saving]);
+
+  function handleInputChange<K extends keyof FormState>(key: K, value: string) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!user || submitDisabled) {
+      return;
+    }
+
+    const cabinetId = form.cabinetId.trim();
+    if (!cabinetId) {
+      setError("請選擇櫃子");
+      return;
+    }
+
+    const titleZh = form.titleZh.trim();
+    if (!titleZh) {
+      setError("中文標題必填");
+      return;
+    }
+
+    const sourceUrl = form.sourceUrl.trim();
+    if (sourceUrl && !isValidHttpUrl(sourceUrl)) {
+      setError("請輸入有效的來源連結");
+      return;
+    }
+
+    const thumbUrl = form.thumbUrl.trim();
+    if (thumbUrl && !isValidHttpUrl(thumbUrl)) {
+      setError("請輸入有效的縮圖連結");
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      const db = getFirebaseDb();
+      if (!db) {
+        throw new Error("Firebase 尚未設定");
+      }
+
+      const links = sourceUrl
+        ? [
+            {
+              label: "來源",
+              url: sourceUrl,
+              isPrimary: true,
+            },
+          ]
+        : [];
+
+      const docRef = await addDoc(collection(db, "item"), {
+        uid: user.uid,
+        cabinetId,
+        titleZh,
+        titleAlt: null,
+        author: null,
+        tags: [],
+        links,
+        thumbUrl: thumbUrl || null,
+        progressNote: null,
+        insightNote: null,
+        note: null,
+        appearances: [],
+        rating: null,
+        status: "planning",
+        updateFrequency: null,
+        nextUpdateAt: null,
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+      });
+
+      router.replace(`/item/${docRef.id}`);
+    } catch (err) {
+      console.error("快速新增物件失敗", err);
+      if (err instanceof Error && err.message) {
+        setError(err.message);
+      } else {
+        setError("建立物件時發生錯誤");
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const inputClass =
+    "h-12 w-full rounded-xl border border-gray-200 bg-white px-4 text-base shadow-sm focus:border-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-400";
+
+  if (!authChecked) {
+    return (
+      <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+        <div className="mx-auto w-full max-w-2xl rounded-2xl border bg-white/70 p-6 text-base shadow-sm">
+          正在確認登入狀態…
+        </div>
+      </main>
+    );
+  }
+
+  if (!user) {
+    return (
+      <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+        <div className="mx-auto flex w-full max-w-2xl flex-col gap-4 rounded-2xl border bg-white/70 p-6 shadow-sm">
+          <h1 className="text-2xl font-semibold text-gray-900">快速新增物件</h1>
+          <p className="text-base text-gray-600">
+            未登入。請前往
+            <Link href="/login" className="ml-1 underline">
+              /login
+            </Link>
+            以管理物件，或回到
+            <Link href="/" className="ml-1 underline">
+              首頁
+            </Link>
+            了解更多功能。
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+      <div className="mx-auto flex w-full max-w-2xl flex-col gap-6">
+        <header className="space-y-2">
+          <h1 className="text-2xl font-semibold text-gray-900">快速新增物件</h1>
+          <p className="text-sm text-gray-500">
+            輸入必要資訊即可建立物件。稍後仍可於完整編輯頁面補充詳細資料。
+          </p>
+        </header>
+
+        <section className="space-y-4 rounded-2xl border bg-white/70 p-6 shadow-sm">
+          {error && (
+            <div className="rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">
+              {error}
+            </div>
+          )}
+
+          {loadingCabinets ? (
+            <div className="rounded-xl bg-gray-100 px-4 py-3 text-sm text-gray-600">
+              正在載入櫃子清單…
+            </div>
+          ) : null}
+
+          {!loadingCabinets && !hasCabinet ? (
+            <div className="rounded-xl bg-amber-50 px-4 py-3 text-sm text-amber-800">
+              尚未建立任何櫃子，無法新增物件。請先前往
+              <Link href="/cabinets" className="ml-1 underline">
+                我的櫃子
+              </Link>
+              建立櫃子。
+            </div>
+          ) : null}
+
+          <form className="space-y-4" onSubmit={handleSubmit}>
+            <div className="space-y-2">
+              <label htmlFor="cabinet" className="text-sm font-medium text-gray-700">
+                所屬櫃子
+              </label>
+              <select
+                id="cabinet"
+                className={inputClass}
+                value={form.cabinetId}
+                onChange={(event) => handleInputChange("cabinetId", event.target.value)}
+                disabled={!hasCabinet || saving}
+                required
+              >
+                {hasCabinet ? (
+                  cabinets.map((cabinet) => (
+                    <option key={cabinet.id} value={cabinet.id}>
+                      {cabinet.name || "未命名櫃子"}
+                    </option>
+                  ))
+                ) : (
+                  <option value="">請先建立櫃子</option>
+                )}
+              </select>
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="titleZh" className="text-sm font-medium text-gray-700">
+                中文標題
+              </label>
+              <input
+                id="titleZh"
+                type="text"
+                className={inputClass}
+                value={form.titleZh}
+                onChange={(event) => handleInputChange("titleZh", event.target.value)}
+                placeholder="請輸入中文標題"
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="sourceUrl" className="text-sm font-medium text-gray-700">
+                來源連結
+              </label>
+              <input
+                id="sourceUrl"
+                type="url"
+                className={inputClass}
+                value={form.sourceUrl}
+                onChange={(event) => handleInputChange("sourceUrl", event.target.value)}
+                placeholder="https://example.com"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="thumbUrl" className="text-sm font-medium text-gray-700">
+                縮圖連結（可不填）
+              </label>
+              <input
+                id="thumbUrl"
+                type="url"
+                className={inputClass}
+                value={form.thumbUrl}
+                onChange={(event) => handleInputChange("thumbUrl", event.target.value)}
+                placeholder="https://i.imgur.com/..."
+              />
+            </div>
+
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                className={buttonClass({ variant: "primary", size: "lg" })}
+                disabled={submitDisabled}
+              >
+                {saving ? "建立中…" : "建立物件"}
+              </button>
+            </div>
+          </form>
+        </section>
+      </div>
+    </main>
+  );
+}
+

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -202,16 +202,16 @@ export default function LoginPage() {
           </form>
 
           {error && (
-            <div className="mt-4 rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+            <div className="mt-4 break-anywhere rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
           )}
           {message && (
-            <div className="mt-4 rounded-xl bg-emerald-50 px-4 py-3 text-sm text-emerald-700">{message}</div>
+            <div className="mt-4 break-anywhere rounded-xl bg-emerald-50 px-4 py-3 text-sm text-emerald-700">{message}</div>
           )}
 
           {user && (
             <div className="mt-6 space-y-3 rounded-xl bg-gray-50 px-4 py-3 text-sm text-gray-700">
               <p>
-                已以 <span className="font-medium text-gray-900">{user.email ?? "已登入"}</span> 登入。
+                已以 <span className="break-anywhere font-medium text-gray-900">{user.email ?? "已登入"}</span> 登入。
               </p>
               <div className="flex flex-col gap-2 sm:flex-row">
                 <button

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -190,13 +190,15 @@ export default function LoginPage() {
               />
             </label>
 
-            <button
-              type="submit"
-              disabled={loading}
-              className="h-12 w-full rounded-xl bg-gray-900 text-base font-medium text-white shadow transition hover:bg-black/90 disabled:cursor-not-allowed disabled:opacity-70"
-            >
-              {loading ? `${modeLabel}中…` : `${modeLabel}並前往我的櫃子`}
-            </button>
+            <div className="pt-3">
+              <button
+                type="submit"
+                disabled={loading}
+                className="h-12 w-full rounded-xl bg-gray-900 text-base font-medium text-white shadow transition hover:bg-black/90 disabled:cursor-not-allowed disabled:opacity-70"
+              >
+                {loading ? `${modeLabel}中…` : `${modeLabel}並前往我的櫃子`}
+              </button>
+            </div>
           </form>
 
           {error && (

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -40,6 +40,7 @@ export default function AppHeader() {
       { href: "/", label: "首頁" },
       { href: "/cabinets", label: "我的櫃子" },
       { href: "/item/new", label: "新增物件" },
+      { href: "/item/quick-add", label: "快速新增物件" },
     ],
     []
   );

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -86,10 +86,17 @@ export default function ItemCard({ item }: ItemCardProps) {
     <article className="space-y-6 rounded-3xl border border-gray-100 bg-white/90 p-6 shadow-sm">
       <div className="flex items-start justify-between gap-3">
         <div className="space-y-1">
-          <h3 className="text-2xl font-semibold leading-tight text-gray-900">
+          <h3
+            className="line-clamp-2 break-words text-2xl font-semibold leading-tight text-gray-900"
+            title={item.titleZh}
+          >
             {item.titleZh}
           </h3>
-          {item.titleAlt && <p className="text-sm text-gray-500">{item.titleAlt}</p>}
+          {item.titleAlt && (
+            <p className="line-clamp-2 break-words text-sm text-gray-500" title={item.titleAlt}>
+              {item.titleAlt}
+            </p>
+          )}
         </div>
         <button
           type="button"
@@ -166,20 +173,30 @@ export default function ItemCard({ item }: ItemCardProps) {
             <span>更新頻率</span>
           </div>
           <div className="grid grid-cols-2 gap-x-6 font-medium text-gray-900">
-            <span>{statusLabel}</span>
-            <span>{updateFrequencyLabel}</span>
+            <span className="line-clamp-2 break-words" title={statusLabel}>
+              {statusLabel}
+            </span>
+            <span className="line-clamp-2 break-words" title={updateFrequencyLabel}>
+              {updateFrequencyLabel}
+            </span>
           </div>
           <div className="grid grid-cols-2 gap-x-6 text-xs text-gray-500">
             <span>下次更新</span>
             <span>評分</span>
           </div>
           <div className="grid grid-cols-2 gap-x-6 font-medium text-gray-900">
-            <span>{nextUpdateText}</span>
-            <span>{ratingDisplay}</span>
+            <span className="line-clamp-2 break-words" title={nextUpdateText}>
+              {nextUpdateText}
+            </span>
+            <span className="line-clamp-2 break-words" title={ratingDisplay}>
+              {ratingDisplay}
+            </span>
           </div>
           <div className="space-y-1">
             <div className="text-xs text-gray-500">作者 / 製作</div>
-            <div className="font-medium text-gray-900">{authorDisplay}</div>
+            <div className="line-clamp-2 break-words font-medium text-gray-900" title={authorDisplay}>
+              {authorDisplay}
+            </div>
           </div>
         </div>
       </div>
@@ -220,7 +237,9 @@ export default function ItemCard({ item }: ItemCardProps) {
 
       <div className="space-y-2 rounded-2xl border border-gray-100 bg-gray-50 px-4 py-3">
         <div className="text-sm font-medium text-gray-900">主進度</div>
-        <div className="text-sm text-gray-700">{summary}</div>
+        <div className="line-clamp-2 break-words text-sm text-gray-700" title={summary}>
+          {summary}
+        </div>
         {primary?.updatedAt && (
           <div className="text-xs text-gray-500">
             主進度更新於：{formatTimestamp(primary.updatedAt)}
@@ -229,12 +248,18 @@ export default function ItemCard({ item }: ItemCardProps) {
       </div>
 
       {item.progressNote && (
-        <div className="rounded-2xl bg-blue-50 px-4 py-3 text-sm text-blue-800">
+        <div
+          className="line-clamp-2 break-words rounded-2xl bg-blue-50 px-4 py-3 text-sm text-blue-800"
+          title={item.progressNote}
+        >
           進度備註：{item.progressNote}
         </div>
       )}
       {item.note && (
-        <div className="rounded-2xl bg-gray-100 px-4 py-3 text-sm text-gray-700">
+        <div
+          className="line-clamp-2 break-words rounded-2xl bg-gray-100 px-4 py-3 text-sm text-gray-700"
+          title={item.note}
+        >
           備註：{item.note}
         </div>
       )}

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -95,13 +95,13 @@ export default function ItemCard({ item }: ItemCardProps) {
       <div className="flex items-start justify-between gap-3">
         <div className="space-y-1">
           <h3
-            className="line-clamp-2 break-words text-2xl font-semibold leading-tight text-gray-900"
+            className="line-clamp-2 break-anywhere text-2xl font-semibold leading-tight text-gray-900"
             title={item.titleZh}
           >
             {item.titleZh}
           </h3>
           {item.titleAlt && (
-            <p className="line-clamp-2 break-words text-sm text-gray-500" title={item.titleAlt}>
+            <p className="line-clamp-2 break-anywhere text-sm text-gray-500" title={item.titleAlt}>
               {item.titleAlt}
             </p>
           )}
@@ -185,10 +185,10 @@ export default function ItemCard({ item }: ItemCardProps) {
             <span>更新頻率</span>
           </div>
           <div className="grid grid-cols-2 gap-x-6 font-medium text-gray-900">
-            <span className="line-clamp-2 break-words" title={statusLabel}>
+            <span className="line-clamp-2 break-anywhere" title={statusLabel}>
               {statusLabel}
             </span>
-            <span className="line-clamp-2 break-words" title={updateFrequencyLabel}>
+            <span className="line-clamp-2 break-anywhere" title={updateFrequencyLabel}>
               {updateFrequencyLabel}
             </span>
           </div>
@@ -197,16 +197,16 @@ export default function ItemCard({ item }: ItemCardProps) {
             <span>評分</span>
           </div>
           <div className="grid grid-cols-2 gap-x-6 font-medium text-gray-900">
-            <span className="line-clamp-2 break-words" title={nextUpdateText}>
+            <span className="line-clamp-2 break-anywhere" title={nextUpdateText}>
               {nextUpdateText}
             </span>
-            <span className="line-clamp-2 break-words" title={ratingDisplay}>
+            <span className="line-clamp-2 break-anywhere" title={ratingDisplay}>
               {ratingDisplay}
             </span>
           </div>
           <div className="space-y-1">
             <div className="text-xs text-gray-500">作者 / 製作</div>
-            <div className="line-clamp-2 break-words font-medium text-gray-900" title={authorDisplay}>
+            <div className="line-clamp-2 break-anywhere font-medium text-gray-900" title={authorDisplay}>
               {authorDisplay}
             </div>
           </div>
@@ -223,7 +223,7 @@ export default function ItemCard({ item }: ItemCardProps) {
                   return (
                     <span
                       key={tag}
-                      className="rounded-full border border-gray-200 bg-gray-100 px-3 py-1"
+                      className="break-anywhere rounded-full border border-gray-200 bg-gray-100 px-3 py-1"
                     >
                       #{tag}
                     </span>
@@ -236,7 +236,7 @@ export default function ItemCard({ item }: ItemCardProps) {
                   <Link
                     key={tag}
                     href={tagHref}
-                    className="rounded-full border border-gray-200 bg-white px-3 py-1 transition hover:border-blue-400 hover:bg-blue-50 hover:text-blue-700"
+                    className="break-anywhere rounded-full border border-gray-200 bg-white px-3 py-1 transition hover:border-blue-400 hover:bg-blue-50 hover:text-blue-700"
                   >
                     #{tag}
                   </Link>
@@ -249,7 +249,7 @@ export default function ItemCard({ item }: ItemCardProps) {
 
       <div className="space-y-2 rounded-2xl border border-gray-100 bg-gray-50 px-4 py-3">
         <div className="text-sm font-medium text-gray-900">主進度</div>
-        <div className="line-clamp-2 break-words text-sm text-gray-700" title={summary}>
+        <div className="line-clamp-2 break-anywhere text-sm text-gray-700" title={summary}>
           {summary}
         </div>
         {primary?.updatedAt && (
@@ -261,7 +261,7 @@ export default function ItemCard({ item }: ItemCardProps) {
 
       {item.progressNote && (
         <div
-          className="line-clamp-2 break-words rounded-2xl bg-blue-50 px-4 py-3 text-sm text-blue-800"
+          className="line-clamp-2 break-anywhere rounded-2xl bg-blue-50 px-4 py-3 text-sm text-blue-800"
           title={item.progressNote}
         >
           進度備註：{item.progressNote}
@@ -269,7 +269,7 @@ export default function ItemCard({ item }: ItemCardProps) {
       )}
       {item.note && (
         <div
-          className="line-clamp-2 break-words rounded-2xl bg-gray-100 px-4 py-3 text-sm text-gray-700"
+          className="line-clamp-2 break-anywhere rounded-2xl bg-gray-100 px-4 py-3 text-sm text-gray-700"
           title={item.note}
         >
           備註：{item.note}
@@ -278,7 +278,7 @@ export default function ItemCard({ item }: ItemCardProps) {
 
       {(error || success) && (
         <div
-          className={`rounded-2xl px-4 py-3 text-sm ${
+          className={`break-anywhere rounded-2xl px-4 py-3 text-sm ${
             error
               ? "bg-red-50 text-red-700"
               : "bg-emerald-50 text-emerald-700"

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -6,7 +6,7 @@ import { useMemo } from "react";
 import type { Timestamp } from "firebase/firestore";
 
 import { usePrimaryProgress } from "@/hooks/usePrimaryProgress";
-import { isOptimizedImageUrl } from "@/lib/image-utils";
+import { DEFAULT_THUMB_TRANSFORM, isOptimizedImageUrl } from "@/lib/image-utils";
 import {
   ITEM_STATUS_OPTIONS,
   UPDATE_FREQUENCY_OPTIONS,
@@ -50,6 +50,14 @@ export default function ItemCard({ item }: ItemCardProps) {
   const { primary, summary, updating, loading, error, success, increment } =
     usePrimaryProgress(item);
   const statusLabel = statusLabelMap.get(item.status) ?? item.status;
+  const thumbTransform = item.thumbTransform ?? DEFAULT_THUMB_TRANSFORM;
+  const thumbStyle = useMemo(
+    () => ({
+      transform: `translate(${thumbTransform.offsetX}%, ${thumbTransform.offsetY}%) scale(${thumbTransform.scale})`,
+      transformOrigin: "center",
+    }),
+    [thumbTransform.offsetX, thumbTransform.offsetY, thumbTransform.scale]
+  );
 
   const primaryLink = useMemo(() => {
     if (!item.links || item.links.length === 0) {
@@ -121,14 +129,18 @@ export default function ItemCard({ item }: ItemCardProps) {
                 fill
                 sizes="80px"
                 className="object-cover"
+                style={thumbStyle}
+                draggable={false}
               />
             ) : (
               /* eslint-disable-next-line @next/next/no-img-element */
               <img
                 src={item.thumbUrl}
                 alt={`${item.titleZh} 縮圖`}
-                className="h-full w-full object-cover"
+                className="h-full w-full select-none object-cover"
+                style={thumbStyle}
                 loading="lazy"
+                draggable={false}
               />
             )
           ) : (

--- a/src/components/ItemForm.tsx
+++ b/src/components/ItemForm.tsx
@@ -1023,12 +1023,12 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
           </div>
 
           {error && (
-            <div className="rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">
+            <div className="break-anywhere rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">
               {error}
             </div>
           )}
           {message && (
-            <div className="rounded-xl bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+            <div className="break-anywhere rounded-xl bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
               {message}
             </div>
           )}
@@ -1162,12 +1162,12 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
                 </div>
 
                 {tagStatus.error ? (
-                  <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-600">
+                  <div className="break-anywhere rounded-xl border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-600">
                     {tagStatus.error}
                   </div>
                 ) : null}
                 {tagStatus.message ? (
-                  <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-2 text-sm text-emerald-700">
+                  <div className="break-anywhere rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-2 text-sm text-emerald-700">
                     {tagStatus.message}
                   </div>
                 ) : null}
@@ -1343,6 +1343,7 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
                 imageUrl={form.thumbUrl.trim()}
                 value={form.thumbTransform}
                 onClose={() => setThumbEditorOpen(false)}
+                shape="portrait"
                 onApply={(next) => {
                   setForm((prev) => ({
                     ...prev,

--- a/src/components/ItemForm.tsx
+++ b/src/components/ItemForm.tsx
@@ -277,13 +277,21 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
             const createdAt = data?.createdAt;
             const createdMs =
               createdAt instanceof Timestamp ? createdAt.toMillis() : 0;
+            const orderValue =
+              typeof data?.order === "number" ? data.order : createdMs;
             return {
               id: docSnap.id,
               name: (data?.name as string) ?? "",
               createdMs,
+              order: orderValue,
             };
           })
-          .sort((a, b) => b.createdMs - a.createdMs)
+          .sort((a, b) => {
+            if (a.order === b.order) {
+              return b.createdMs - a.createdMs;
+            }
+            return b.order - a.order;
+          })
           .map((item) => ({ id: item.id, name: item.name }));
         setCabinets(rows);
       })

--- a/src/components/ItemListRow.tsx
+++ b/src/components/ItemListRow.tsx
@@ -83,14 +83,14 @@ export default function ItemListRow({ item }: ItemListRowProps) {
           <div className="min-w-0 flex-1 space-y-1">
             <Link
               href={detailHref}
-              className="block text-base font-semibold text-gray-900 transition hover:text-blue-600 line-clamp-2 break-words"
+              className="block text-base font-semibold text-gray-900 transition hover:text-blue-600 line-clamp-2 break-anywhere"
               title={item.titleZh}
             >
               {item.titleZh}
             </Link>
             {item.titleAlt && (
               <div
-                className="line-clamp-2 break-words text-xs text-gray-500"
+                className="line-clamp-2 break-anywhere text-xs text-gray-500"
                 title={item.titleAlt}
               >
                 {item.titleAlt}
@@ -103,7 +103,7 @@ export default function ItemListRow({ item }: ItemListRowProps) {
                     return (
                       <span
                         key={tag}
-                        className="rounded-full border border-gray-200 bg-white px-3 py-1"
+                        className="break-anywhere rounded-full border border-gray-200 bg-white px-3 py-1"
                       >
                         #{tag}
                       </span>
@@ -116,7 +116,7 @@ export default function ItemListRow({ item }: ItemListRowProps) {
                     <Link
                       key={tag}
                       href={tagHref}
-                      className="rounded-full border border-gray-200 bg-white px-3 py-1 transition hover:border-blue-400 hover:bg-blue-50 hover:text-blue-700"
+                      className="break-anywhere rounded-full border border-gray-200 bg-white px-3 py-1 transition hover:border-blue-400 hover:bg-blue-50 hover:text-blue-700"
                     >
                       #{tag}
                     </Link>
@@ -129,7 +129,7 @@ export default function ItemListRow({ item }: ItemListRowProps) {
 
         <div className="flex w-full flex-col gap-3 sm:w-auto sm:min-w-[160px] sm:max-w-[240px] sm:flex-none sm:items-end">
           <div
-            className="line-clamp-2 break-words text-sm font-medium text-gray-700 sm:text-right"
+            className="line-clamp-2 break-anywhere text-sm font-medium text-gray-700 sm:text-right"
             title={listDisplay}
           >
             {listDisplay}
@@ -167,7 +167,7 @@ export default function ItemListRow({ item }: ItemListRowProps) {
 
       {(error || success) && (
         <div
-          className={`mt-3 rounded-xl px-3 py-2 text-xs ${
+          className={`mt-3 break-anywhere rounded-xl px-3 py-2 text-xs ${
             error ? "bg-red-50 text-red-700" : "bg-emerald-50 text-emerald-700"
           }`}
         >

--- a/src/components/ItemListRow.tsx
+++ b/src/components/ItemListRow.tsx
@@ -43,40 +43,46 @@ export default function ItemListRow({ item }: ItemListRowProps) {
             href={detailHref}
             className="relative h-16 w-12 shrink-0 overflow-hidden rounded-lg border border-gray-200 bg-gray-100 shadow-inner"
           >
-          {item.thumbUrl ? (
-            canUseOptimizedThumb ? (
-              <Image
-                src={item.thumbUrl}
-                alt={`${item.titleZh} 縮圖`}
-                fill
-                sizes="48px"
-                className="object-cover"
-              />
+            {item.thumbUrl ? (
+              canUseOptimizedThumb ? (
+                <Image
+                  src={item.thumbUrl}
+                  alt={`${item.titleZh} 縮圖`}
+                  fill
+                  sizes="48px"
+                  className="object-cover"
+                />
+              ) : (
+                /* eslint-disable-next-line @next/next/no-img-element */
+                <img
+                  src={item.thumbUrl}
+                  alt={`${item.titleZh} 縮圖`}
+                  className="h-full w-full object-cover"
+                  loading="lazy"
+                />
+              )
             ) : (
-              /* eslint-disable-next-line @next/next/no-img-element */
-              <img
-                src={item.thumbUrl}
-                alt={`${item.titleZh} 縮圖`}
-                className="h-full w-full object-cover"
-                loading="lazy"
-              />
-            )
-          ) : (
-            <div className="flex h-full w-full items-center justify-center text-[10px] font-medium text-gray-400">
-              無封面
-            </div>
-          )}
+              <div className="flex h-full w-full items-center justify-center text-[10px] font-medium text-gray-400">
+                無封面
+              </div>
+            )}
           </Link>
 
           <div className="min-w-0 flex-1 space-y-1">
             <Link
               href={detailHref}
-              className="block truncate text-base font-semibold text-gray-900 transition hover:text-blue-600"
+              className="block text-base font-semibold text-gray-900 transition hover:text-blue-600 line-clamp-2 break-words"
+              title={item.titleZh}
             >
               {item.titleZh}
             </Link>
             {item.titleAlt && (
-              <div className="truncate text-xs text-gray-500">{item.titleAlt}</div>
+              <div
+                className="line-clamp-2 break-words text-xs text-gray-500"
+                title={item.titleAlt}
+              >
+                {item.titleAlt}
+              </div>
             )}
             {tags.length > 0 && (
               <div className="flex flex-wrap gap-2 pt-1 text-xs text-gray-600">
@@ -109,8 +115,11 @@ export default function ItemListRow({ item }: ItemListRowProps) {
           </div>
         </div>
 
-        <div className="flex w-full flex-col gap-3 sm:w-auto sm:min-w-[160px] sm:flex-none sm:items-end">
-          <div className="text-sm font-medium text-gray-700 sm:text-right">
+        <div className="flex w-full flex-col gap-3 sm:w-auto sm:min-w-[160px] sm:max-w-[240px] sm:flex-none sm:items-end">
+          <div
+            className="line-clamp-2 break-words text-sm font-medium text-gray-700 sm:text-right"
+            title={listDisplay}
+          >
             {listDisplay}
           </div>
           <div className="flex flex-wrap gap-2 sm:flex-nowrap sm:justify-end">

--- a/src/components/ItemListRow.tsx
+++ b/src/components/ItemListRow.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useMemo } from "react";
 
 import { usePrimaryProgress } from "@/hooks/usePrimaryProgress";
-import { isOptimizedImageUrl } from "@/lib/image-utils";
+import { DEFAULT_THUMB_TRANSFORM, isOptimizedImageUrl } from "@/lib/image-utils";
 import type { ItemRecord } from "@/lib/types";
 import { buttonClass } from "@/lib/ui";
 
@@ -32,6 +32,14 @@ export default function ItemListRow({ item }: ItemListRowProps) {
   }, [item.links]);
 
   const canUseOptimizedThumb = isOptimizedImageUrl(item.thumbUrl);
+  const thumbTransform = item.thumbTransform ?? DEFAULT_THUMB_TRANSFORM;
+  const thumbStyle = useMemo(
+    () => ({
+      transform: `translate(${thumbTransform.offsetX}%, ${thumbTransform.offsetY}%) scale(${thumbTransform.scale})`,
+      transformOrigin: "center",
+    }),
+    [thumbTransform.offsetX, thumbTransform.offsetY, thumbTransform.scale]
+  );
   const tags = item.tags ?? [];
   const detailHref = `/item/${item.id}`;
 
@@ -51,14 +59,18 @@ export default function ItemListRow({ item }: ItemListRowProps) {
                   fill
                   sizes="48px"
                   className="object-cover"
+                  style={thumbStyle}
+                  draggable={false}
                 />
               ) : (
                 /* eslint-disable-next-line @next/next/no-img-element */
                 <img
                   src={item.thumbUrl}
                   alt={`${item.titleZh} 縮圖`}
-                  className="h-full w-full object-cover"
+                  className="h-full w-full select-none object-cover"
+                  style={thumbStyle}
                   loading="lazy"
+                  draggable={false}
                 />
               )
             ) : (

--- a/src/components/ThumbEditorDialog.tsx
+++ b/src/components/ThumbEditorDialog.tsx
@@ -171,7 +171,7 @@ export default function ThumbEditorDialog({
 
         <div
           ref={containerRef}
-          className="relative mx-auto mt-6 aspect-[3/4] w-full max-w-sm overflow-hidden rounded-2xl border border-gray-200 bg-gray-100"
+          className="relative mx-auto mt-6 aspect-square w-full max-w-sm overflow-hidden rounded-2xl border border-gray-200 bg-gray-100"
           onPointerDown={handlePointerDown}
           onPointerMove={handlePointerMove}
           onPointerUp={handlePointerUp}

--- a/src/components/ThumbEditorDialog.tsx
+++ b/src/components/ThumbEditorDialog.tsx
@@ -15,6 +15,7 @@ type ThumbEditorDialogProps = {
   value: ThumbTransform;
   onApply: (value: ThumbTransform) => void;
   onClose: () => void;
+  shape?: "square" | "portrait";
 };
 
 type DragState = {
@@ -31,6 +32,7 @@ export default function ThumbEditorDialog({
   value,
   onApply,
   onClose,
+  shape = "square",
 }: ThumbEditorDialogProps) {
   const [local, setLocal] = useState<ThumbTransform>(() =>
     clampThumbTransform(value)
@@ -141,6 +143,11 @@ export default function ThumbEditorDialog({
     return null;
   }
 
+  const previewClassName =
+    shape === "portrait"
+      ? "relative mx-auto mt-6 aspect-[3/4] w-full max-w-sm overflow-hidden rounded-2xl border border-gray-200 bg-gray-100 sm:max-w-md"
+      : "relative mx-auto mt-6 aspect-square w-full max-w-sm overflow-hidden rounded-2xl border border-gray-200 bg-gray-100";
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-8"
@@ -171,7 +178,7 @@ export default function ThumbEditorDialog({
 
         <div
           ref={containerRef}
-          className="relative mx-auto mt-6 aspect-square w-full max-w-sm overflow-hidden rounded-2xl border border-gray-200 bg-gray-100"
+          className={previewClassName}
           onPointerDown={handlePointerDown}
           onPointerMove={handlePointerMove}
           onPointerUp={handlePointerUp}

--- a/src/components/ThumbEditorDialog.tsx
+++ b/src/components/ThumbEditorDialog.tsx
@@ -1,0 +1,294 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { PointerEvent as ReactPointerEvent } from "react";
+
+import {
+  clampThumbTransform,
+  DEFAULT_THUMB_TRANSFORM,
+} from "@/lib/image-utils";
+import type { ThumbTransform } from "@/lib/types";
+
+type ThumbEditorDialogProps = {
+  open: boolean;
+  imageUrl: string;
+  value: ThumbTransform;
+  onApply: (value: ThumbTransform) => void;
+  onClose: () => void;
+};
+
+type DragState = {
+  pointerId: number;
+  startX: number;
+  startY: number;
+  startOffsetX: number;
+  startOffsetY: number;
+};
+
+export default function ThumbEditorDialog({
+  open,
+  imageUrl,
+  value,
+  onApply,
+  onClose,
+}: ThumbEditorDialogProps) {
+  const [local, setLocal] = useState<ThumbTransform>(() =>
+    clampThumbTransform(value)
+  );
+  const [imageLoaded, setImageLoaded] = useState(false);
+  const [imageError, setImageError] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const dragStateRef = useRef<DragState | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    setLocal(clampThumbTransform(value));
+  }, [open, value]);
+
+  useEffect(() => {
+    if (!open) {
+      setImageLoaded(false);
+      setImageError(null);
+      dragStateRef.current = null;
+      return;
+    }
+    setImageLoaded(false);
+    setImageError(null);
+  }, [open, imageUrl]);
+
+  useEffect(() => {
+    if (!open || typeof window === "undefined") {
+      return;
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose]);
+
+  const hasImage = imageUrl.trim().length > 0;
+  const canApply = hasImage && imageLoaded && !imageError;
+
+  const handlePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!hasImage || !imageLoaded) {
+      return;
+    }
+    event.preventDefault();
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    container.setPointerCapture?.(event.pointerId);
+    dragStateRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      startOffsetX: local.offsetX,
+      startOffsetY: local.offsetY,
+    };
+  };
+
+  const handlePointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const dragState = dragStateRef.current;
+    if (!dragState || dragState.pointerId !== event.pointerId) {
+      return;
+    }
+    event.preventDefault();
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    const width = container.clientWidth || 1;
+    const height = container.clientHeight || 1;
+    const deltaX = ((event.clientX - dragState.startX) / width) * 100;
+    const deltaY = ((event.clientY - dragState.startY) / height) * 100;
+    setLocal((prev) =>
+      clampThumbTransform({
+        ...prev,
+        offsetX: dragState.startOffsetX + deltaX,
+        offsetY: dragState.startOffsetY + deltaY,
+      })
+    );
+  };
+
+  const endDragging = (pointerId: number) => {
+    const container = containerRef.current;
+    if (container) {
+      container.releasePointerCapture?.(pointerId);
+    }
+    dragStateRef.current = null;
+  };
+
+  const handlePointerUp = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (dragStateRef.current && dragStateRef.current.pointerId === event.pointerId) {
+      endDragging(event.pointerId);
+    }
+  };
+
+  const handlePointerLeave = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (dragStateRef.current && dragStateRef.current.pointerId === event.pointerId) {
+      endDragging(event.pointerId);
+    }
+  };
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-8"
+      role="dialog"
+      aria-modal="true"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-3xl rounded-3xl bg-white p-6 shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h2 className="text-2xl font-semibold text-gray-900">圖片編輯</h2>
+            <p className="mt-1 text-sm text-gray-500">
+              拖曳預覽以調整顯示位置，使用滑桿縮放圖片。此調整僅影響縮圖顯示範圍。
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="h-10 w-10 rounded-full border border-gray-200 text-xl text-gray-500 transition hover:border-gray-300 hover:text-gray-700"
+            aria-label="關閉圖片編輯視窗"
+          >
+            ×
+          </button>
+        </div>
+
+        <div
+          ref={containerRef}
+          className="relative mx-auto mt-6 aspect-[3/4] w-full max-w-sm overflow-hidden rounded-2xl border border-gray-200 bg-gray-100"
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerLeave={handlePointerLeave}
+        >
+          {!hasImage ? (
+            <div className="flex h-full w-full items-center justify-center px-6 text-center text-sm text-gray-500">
+              請先輸入縮圖連結後再進行圖片編輯。
+            </div>
+          ) : imageError ? (
+            <div className="flex h-full w-full items-center justify-center px-6 text-center text-sm text-red-600">
+              {imageError}
+            </div>
+          ) : (
+            <>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={imageUrl}
+                alt="縮圖預覽"
+                className="pointer-events-none select-none"
+                style={{
+                  width: "100%",
+                  height: "100%",
+                  transform: `translate(${local.offsetX}%, ${local.offsetY}%) scale(${local.scale})`,
+                  transformOrigin: "center",
+                  objectFit: "cover",
+                }}
+                draggable={false}
+                onLoad={() => {
+                  setImageLoaded(true);
+                  setImageError(null);
+                }}
+                onError={() => {
+                  setImageLoaded(false);
+                  setImageError("圖片載入失敗，請確認連結是否有效。");
+                }}
+              />
+              {!imageLoaded && (
+                <div className="absolute inset-0 flex items-center justify-center bg-white/60 text-sm text-gray-500">
+                  圖片載入中…
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        <div className="mt-6 space-y-4">
+          <div className="flex items-center justify-between text-sm text-gray-600">
+            <span>縮放</span>
+            <span className="tabular-nums text-gray-500">
+              {local.scale.toFixed(2)} ×
+            </span>
+          </div>
+          <input
+            type="range"
+            min={1}
+            max={3}
+            step={0.01}
+            value={local.scale}
+            onChange={(event) => {
+              const next = Number(event.target.value);
+              if (Number.isNaN(next)) {
+                return;
+              }
+              setLocal((prev) =>
+                clampThumbTransform({
+                  ...prev,
+                  scale: next,
+                })
+              );
+            }}
+            className="w-full"
+            aria-label="縮放調整"
+          />
+          <div className="grid grid-cols-2 gap-3 text-xs text-gray-500 sm:grid-cols-3">
+            <div>水平位移：{local.offsetX.toFixed(0)}%</div>
+            <div>垂直位移：{local.offsetY.toFixed(0)}%</div>
+            <div className="sm:col-span-1">縮放：{local.scale.toFixed(2)}×</div>
+          </div>
+        </div>
+
+        <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <button
+            type="button"
+            onClick={() => setLocal({ ...DEFAULT_THUMB_TRANSFORM })}
+            className="inline-flex items-center justify-center rounded-xl border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 transition hover:border-gray-300 hover:text-gray-800"
+          >
+            重置顯示範圍
+          </button>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+            <button
+              type="button"
+              onClick={onClose}
+              className="inline-flex items-center justify-center rounded-xl border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 transition hover:border-gray-300 hover:text-gray-800"
+            >
+              取消
+            </button>
+            <button
+              type="button"
+              disabled={!canApply}
+              onClick={() => {
+                if (!canApply) {
+                  return;
+                }
+                onApply(clampThumbTransform(local));
+              }}
+              className={`inline-flex items-center justify-center rounded-xl px-4 py-2 text-sm font-medium transition ${
+                canApply
+                  ? "bg-gray-900 text-white hover:bg-black"
+                  : "cursor-not-allowed bg-gray-300 text-gray-500"
+              }`}
+            >
+              套用調整
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ThumbLinkField.tsx
+++ b/src/components/ThumbLinkField.tsx
@@ -6,14 +6,20 @@ type ThumbLinkFieldProps = {
   value: string;
   onChange: (value: string) => void;
   disabled?: boolean;
+  onEdit?: () => void;
 };
 
 export default function ThumbLinkField({
   value,
   onChange,
   disabled,
+  onEdit,
 }: ThumbLinkFieldProps) {
   const canOpen = useMemo(() => value.trim().length > 0, [value]);
+  const canEdit = useMemo(
+    () => Boolean(onEdit) && canOpen && !disabled,
+    [onEdit, canOpen, disabled]
+  );
 
   return (
     <div className="space-y-2">
@@ -41,6 +47,18 @@ export default function ThumbLinkField({
           >
             開啟
           </a>
+          <button
+            type="button"
+            onClick={onEdit}
+            disabled={!canEdit}
+            className={`h-12 w-[104px] shrink-0 rounded-xl border text-base font-medium transition ${
+              canEdit
+                ? "bg-white text-gray-700 hover:border-blue-300 hover:text-blue-700"
+                : "cursor-not-allowed border-dashed text-gray-400"
+            }`}
+          >
+            圖片編輯
+          </button>
         </div>
       </label>
       <p className="text-xs text-gray-500">

--- a/src/lib/appearances.ts
+++ b/src/lib/appearances.ts
@@ -1,3 +1,4 @@
+import { normalizeThumbTransform } from "./image-utils";
 import type { AppearanceRecord } from "./types";
 
 export function normalizeAppearanceRecords(value: unknown): AppearanceRecord[] {
@@ -13,6 +14,7 @@ export function normalizeAppearanceRecords(value: unknown): AppearanceRecord[] {
     const record = entry as {
       name?: unknown;
       thumbUrl?: unknown;
+      thumbTransform?: unknown;
       note?: unknown;
     };
     const name =
@@ -24,10 +26,12 @@ export function normalizeAppearanceRecords(value: unknown): AppearanceRecord[] {
       typeof record.thumbUrl === "string" ? record.thumbUrl.trim() : "";
     const note =
       typeof record.note === "string" ? record.note.trim() : "";
+    const thumbTransform = normalizeThumbTransform(record.thumbTransform);
 
     result.push({
       name,
       thumbUrl: thumbUrl || null,
+      thumbTransform,
       note: note || null,
     });
   }

--- a/src/lib/image-utils.ts
+++ b/src/lib/image-utils.ts
@@ -1,3 +1,75 @@
+import type { ThumbTransform } from "./types";
+
+const MIN_SCALE = 1;
+const MAX_SCALE = 3;
+const OFFSET_LIMIT = 100;
+
+export const DEFAULT_THUMB_TRANSFORM: ThumbTransform = {
+  scale: 1,
+  offsetX: 0,
+  offsetY: 0,
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+export function clampThumbTransform(transform: ThumbTransform): ThumbTransform {
+  return {
+    scale: clamp(transform.scale, MIN_SCALE, MAX_SCALE),
+    offsetX: clamp(transform.offsetX, -OFFSET_LIMIT, OFFSET_LIMIT),
+    offsetY: clamp(transform.offsetY, -OFFSET_LIMIT, OFFSET_LIMIT),
+  };
+}
+
+export function normalizeThumbTransform(input: unknown): ThumbTransform {
+  if (!input || typeof input !== "object") {
+    return { ...DEFAULT_THUMB_TRANSFORM };
+  }
+  const record = input as {
+    scale?: unknown;
+    offsetX?: unknown;
+    offsetY?: unknown;
+  };
+  const base = { ...DEFAULT_THUMB_TRANSFORM };
+  const scale =
+    typeof record.scale === "number" && Number.isFinite(record.scale)
+      ? record.scale
+      : base.scale;
+  const offsetX =
+    typeof record.offsetX === "number" && Number.isFinite(record.offsetX)
+      ? record.offsetX
+      : base.offsetX;
+  const offsetY =
+    typeof record.offsetY === "number" && Number.isFinite(record.offsetY)
+      ? record.offsetY
+      : base.offsetY;
+  return clampThumbTransform({
+    scale,
+    offsetX,
+    offsetY,
+  });
+}
+
+export function isDefaultThumbTransform(transform: ThumbTransform): boolean {
+  const normalized = clampThumbTransform(transform);
+  return (
+    normalized.scale === DEFAULT_THUMB_TRANSFORM.scale &&
+    normalized.offsetX === DEFAULT_THUMB_TRANSFORM.offsetX &&
+    normalized.offsetY === DEFAULT_THUMB_TRANSFORM.offsetY
+  );
+}
+
+export function prepareThumbTransform(
+  transform: ThumbTransform | null | undefined
+): ThumbTransform | null {
+  if (!transform) {
+    return null;
+  }
+  const clamped = clampThumbTransform(transform);
+  return isDefaultThumbTransform(clamped) ? null : clamped;
+}
+
 export function isOptimizedImageUrl(url?: string | null): boolean {
   if (!url) return false;
   try {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -52,6 +52,12 @@ export const PROGRESS_TYPE_OPTIONS: { value: ProgressType; label: string }[] = [
   { value: "level", label: "等級" },
 ];
 
+export type ThumbTransform = {
+  scale: number;
+  offsetX: number;
+  offsetY: number;
+};
+
 export type ItemLink = {
   label: string;
   url: string;
@@ -74,6 +80,7 @@ export type ItemRecord = {
   tags: string[];
   links: ItemLink[];
   thumbUrl?: string | null;
+  thumbTransform?: ThumbTransform | null;
   progressNote?: string | null;
   insightNote?: string | null;
   note?: string | null;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -67,6 +67,7 @@ export type ItemLink = {
 export type AppearanceRecord = {
   name: string;
   thumbUrl?: string | null;
+  thumbTransform?: ThumbTransform | null;
   note?: string | null;
 };
 

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -5,8 +5,13 @@ import {
   type ItemLink,
   type ItemStatus,
   type ProgressType,
+  type ThumbTransform,
   type UpdateFrequency,
 } from "./types";
+import {
+  clampThumbTransform,
+  DEFAULT_THUMB_TRANSFORM,
+} from "./image-utils";
 
 export type AppearanceFormInput = {
   name?: string | undefined;
@@ -28,6 +33,7 @@ export type ItemFormInput = {
   tags?: string[] | undefined;
   links?: ItemLink[] | undefined;
   thumbUrl?: string | undefined;
+  thumbTransform?: ThumbTransform | undefined;
   progressNote?: string | undefined;
   insightNote?: string | undefined;
   note?: string | undefined;
@@ -46,6 +52,7 @@ export type ItemFormData = {
   tags: string[];
   links: ItemLink[];
   thumbUrl?: string;
+  thumbTransform: ThumbTransform;
   progressNote?: string;
   insightNote?: string;
   note?: string;
@@ -142,6 +149,7 @@ export function parseItemForm(input: ItemFormInput): ItemFormData {
     tags: [],
     links: [],
     appearances: [],
+    thumbTransform: { ...DEFAULT_THUMB_TRANSFORM },
   };
 
   if (input.titleAlt) {
@@ -199,6 +207,27 @@ export function parseItemForm(input: ItemFormInput): ItemFormData {
       validateUrl(thumbUrl, "請輸入有效的縮圖網址");
       data.thumbUrl = thumbUrl;
     }
+  }
+
+  if (input.thumbTransform) {
+    const transform = input.thumbTransform;
+    const scale =
+      typeof transform.scale === "number" && Number.isFinite(transform.scale)
+        ? transform.scale
+        : DEFAULT_THUMB_TRANSFORM.scale;
+    const offsetX =
+      typeof transform.offsetX === "number" && Number.isFinite(transform.offsetX)
+        ? transform.offsetX
+        : DEFAULT_THUMB_TRANSFORM.offsetX;
+    const offsetY =
+      typeof transform.offsetY === "number" && Number.isFinite(transform.offsetY)
+        ? transform.offsetY
+        : DEFAULT_THUMB_TRANSFORM.offsetY;
+    data.thumbTransform = clampThumbTransform({
+      scale,
+      offsetX,
+      offsetY,
+    });
   }
 
   if (input.progressNote) {

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -11,17 +11,20 @@ import {
 import {
   clampThumbTransform,
   DEFAULT_THUMB_TRANSFORM,
+  normalizeThumbTransform,
 } from "./image-utils";
 
 export type AppearanceFormInput = {
   name?: string | undefined;
   thumbUrl?: string | undefined;
+  thumbTransform?: ThumbTransform | undefined;
   note?: string | undefined;
 };
 
 export type AppearanceFormData = {
   name: string;
   thumbUrl?: string;
+  thumbTransform: ThumbTransform;
   note?: string;
 };
 
@@ -265,6 +268,7 @@ export function parseItemForm(input: ItemFormInput): ItemFormData {
       const thumbUrl =
         typeof record.thumbUrl === "string" ? record.thumbUrl.trim() : "";
       const note = typeof record.note === "string" ? record.note.trim() : "";
+      const thumbTransform = normalizeThumbTransform(record.thumbTransform);
 
       if (!name) {
         if (thumbUrl || note) {
@@ -283,6 +287,7 @@ export function parseItemForm(input: ItemFormInput): ItemFormData {
       appearances.push({
         name,
         thumbUrl: thumbUrl || undefined,
+        thumbTransform,
         note: note || undefined,
       });
     });


### PR DESCRIPTION
## Summary
- add a navigation link for quick item creation
- implement a quick add item page with minimal fields that redirects to the new item's detail page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb6913e0b48320b0585dc6793ac47e