### PR TITLE
Implement tag pagination and attribute quick edit

### DIFF
--- a/src/components/ThumbEditorDialog.tsx
+++ b/src/components/ThumbEditorDialog.tsx
@@ -145,8 +145,8 @@ export default function ThumbEditorDialog({
 
   const previewClassName =
     shape === "portrait"
-      ? "relative mx-auto mt-6 aspect-[3/4] w-full max-w-sm overflow-hidden rounded-2xl border border-gray-200 bg-gray-100 sm:max-w-md"
-      : "relative mx-auto mt-6 aspect-square w-full max-w-sm overflow-hidden rounded-2xl border border-gray-200 bg-gray-100";
+      ? "relative mx-auto mt-6 aspect-[3/4] w-full max-w-xs overflow-hidden rounded-2xl border border-gray-200 bg-gray-100 sm:max-w-sm"
+      : "relative mx-auto mt-6 aspect-square w-full max-w-xs overflow-hidden rounded-2xl border border-gray-200 bg-gray-100 sm:max-w-sm";
 
   return (
     <div
@@ -156,7 +156,7 @@ export default function ThumbEditorDialog({
       onClick={onClose}
     >
       <div
-        className="w-full max-w-3xl rounded-3xl bg-white p-6 shadow-2xl"
+        className="w-full max-w-2xl rounded-3xl bg-white p-6 shadow-2xl"
         onClick={(event) => event.stopPropagation()}
       >
         <div className="flex items-start justify-between gap-3">


### PR DESCRIPTION
## Summary
- add searchable pagination with 20-item pages to the cabinet tag management view
- shrink the thumb editor modal and keep appearance thumbnails locked to a square frame
- enable double-click quick editing for item attributes with validation and feedback

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cba2f128a083208bc2bb8e1b3a58c1