### PR TITLE
feat: add favorites support

### DIFF
--- a/src/components/FavoriteToggleButton.tsx
+++ b/src/components/FavoriteToggleButton.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+type FavoriteToggleButtonProps = {
+  isFavorite: boolean;
+  onToggle: () => void;
+  disabled?: boolean;
+  size?: "sm" | "md";
+  className?: string;
+  ariaLabel?: string;
+};
+
+export default function FavoriteToggleButton({
+  isFavorite,
+  onToggle,
+  disabled = false,
+  size = "md",
+  className,
+  ariaLabel,
+}: FavoriteToggleButtonProps) {
+  const buttonSizeClass = size === "sm" ? "h-9 w-9" : "h-10 w-10";
+  const iconSizeClass = size === "sm" ? "h-4 w-4" : "h-5 w-5";
+  const stateClass = isFavorite
+    ? "border-red-200 bg-red-50 text-red-600 hover:bg-red-100"
+    : "border-red-200 bg-white text-red-400 hover:bg-red-50 hover:text-red-500";
+  const composedClassName = [
+    "inline-flex items-center justify-center rounded-full border transition",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-200",
+    "disabled:cursor-not-allowed disabled:opacity-60",
+    buttonSizeClass,
+    stateClass,
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  const label = ariaLabel ?? (isFavorite ? "取消最愛" : "加入最愛");
+
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      disabled={disabled}
+      aria-pressed={isFavorite}
+      aria-label={label}
+      title={label}
+      className={composedClassName}
+    >
+      <svg
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+        className={iconSizeClass}
+        fill={isFavorite ? "currentColor" : "none"}
+        stroke="currentColor"
+        strokeWidth={1.8}
+      >
+        <path
+          d="M12 20s-6.333-4.493-8.485-6.646C1.343 11.182 1.343 7.818 3.515 5.646 5.686 3.475 9.05 3.475 11.222 5.646L12 6.424l.778-.778c2.172-2.171 5.536-2.171 7.707 0 2.172 2.172 2.172 5.536 0 7.708C18.333 15.507 12 20 12 20z"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </button>
+  );
+}
+

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -5,6 +5,8 @@ import Link from "next/link";
 import { useMemo } from "react";
 import type { Timestamp } from "firebase/firestore";
 
+import FavoriteToggleButton from "@/components/FavoriteToggleButton";
+import { useFavoriteToggle } from "@/hooks/useFavoriteToggle";
 import { usePrimaryProgress } from "@/hooks/usePrimaryProgress";
 import { DEFAULT_THUMB_TRANSFORM, isOptimizedImageUrl } from "@/lib/image-utils";
 import {
@@ -49,6 +51,11 @@ function formatDateOnly(timestamp?: Timestamp | null): string {
 export default function ItemCard({ item }: ItemCardProps) {
   const { primary, summary, updating, loading, error, success, increment } =
     usePrimaryProgress(item);
+  const {
+    toggleFavorite,
+    pending: favoritePending,
+    error: favoriteError,
+  } = useFavoriteToggle(item);
   const statusLabel = statusLabelMap.get(item.status) ?? item.status;
   const thumbTransform = item.thumbTransform ?? DEFAULT_THUMB_TRANSFORM;
   const thumbStyle = useMemo(
@@ -106,14 +113,26 @@ export default function ItemCard({ item }: ItemCardProps) {
             </p>
           )}
         </div>
-        <button
-          type="button"
-          onClick={increment}
-          disabled={updating || loading}
-          className={buttonClass({ variant: "primary" })}
-        >
-          {updating ? "+1…" : "+1"}
-        </button>
+        <div className="flex items-center gap-2">
+          <FavoriteToggleButton
+            isFavorite={item.isFavorite}
+            onToggle={toggleFavorite}
+            disabled={favoritePending}
+            ariaLabel={
+              item.isFavorite
+                ? `取消 ${item.titleZh} 最愛`
+                : `將 ${item.titleZh} 設為最愛`
+            }
+          />
+          <button
+            type="button"
+            onClick={increment}
+            disabled={updating || loading}
+            className={buttonClass({ variant: "primary" })}
+          >
+            {updating ? "+1…" : "+1"}
+          </button>
+        </div>
       </div>
 
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
@@ -276,15 +295,15 @@ export default function ItemCard({ item }: ItemCardProps) {
         </div>
       )}
 
-      {(error || success) && (
+      {(favoriteError || error || success) && (
         <div
           className={`break-anywhere rounded-2xl px-4 py-3 text-sm ${
-            error
+            favoriteError || error
               ? "bg-red-50 text-red-700"
               : "bg-emerald-50 text-emerald-700"
           }`}
         >
-          {error ?? success}
+          {favoriteError ?? error ?? success}
         </div>
       )}
     </article>

--- a/src/components/ItemForm.tsx
+++ b/src/components/ItemForm.tsx
@@ -692,6 +692,10 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
         updatedAt: serverTimestamp(),
       };
 
+      if (mode === "create") {
+        docData.isFavorite = false;
+      }
+
       const db = getFirebaseDb();
       if (!db) {
         throw new Error("Firebase 尚未設定");

--- a/src/components/ItemListRow.tsx
+++ b/src/components/ItemListRow.tsx
@@ -4,6 +4,8 @@ import Image from "next/image";
 import Link from "next/link";
 import { useMemo } from "react";
 
+import FavoriteToggleButton from "@/components/FavoriteToggleButton";
+import { useFavoriteToggle } from "@/hooks/useFavoriteToggle";
 import { usePrimaryProgress } from "@/hooks/usePrimaryProgress";
 import { DEFAULT_THUMB_TRANSFORM, isOptimizedImageUrl } from "@/lib/image-utils";
 import type { ItemRecord } from "@/lib/types";
@@ -16,6 +18,11 @@ type ItemListRowProps = {
 export default function ItemListRow({ item }: ItemListRowProps) {
   const { listDisplay, increment, updating, loading, error, success } =
     usePrimaryProgress(item);
+  const {
+    toggleFavorite,
+    pending: favoritePending,
+    error: favoriteError,
+  } = useFavoriteToggle(item);
 
   const primaryLink = useMemo(() => {
     if (!item.links || item.links.length === 0) {
@@ -128,11 +135,24 @@ export default function ItemListRow({ item }: ItemListRowProps) {
         </div>
 
         <div className="flex w-full flex-col gap-3 sm:w-auto sm:min-w-[160px] sm:max-w-[240px] sm:flex-none sm:items-end">
-          <div
-            className="line-clamp-2 break-anywhere text-sm font-medium text-gray-700 sm:text-right"
-            title={listDisplay}
-          >
-            {listDisplay}
+          <div className="flex items-start justify-between gap-3 sm:items-center">
+            <div
+              className="flex-1 break-anywhere text-sm font-medium text-gray-700 sm:text-right"
+              title={listDisplay}
+            >
+              {listDisplay}
+            </div>
+            <FavoriteToggleButton
+              isFavorite={item.isFavorite}
+              onToggle={toggleFavorite}
+              disabled={favoritePending}
+              size="sm"
+              ariaLabel={
+                item.isFavorite
+                  ? `取消 ${item.titleZh} 最愛`
+                  : `將 ${item.titleZh} 設為最愛`
+              }
+            />
           </div>
           <div className="flex flex-wrap gap-2 sm:flex-nowrap sm:justify-end">
             {primaryLink ? (
@@ -165,13 +185,15 @@ export default function ItemListRow({ item }: ItemListRowProps) {
         </div>
       </div>
 
-      {(error || success) && (
+      {(favoriteError || error || success) && (
         <div
           className={`mt-3 break-anywhere rounded-xl px-3 py-2 text-xs ${
-            error ? "bg-red-50 text-red-700" : "bg-emerald-50 text-emerald-700"
+            favoriteError || error
+              ? "bg-red-50 text-red-700"
+              : "bg-emerald-50 text-emerald-700"
           }`}
         >
-          {error ?? success}
+          {favoriteError ?? error ?? success}
         </div>
       )}
     </article>

--- a/src/hooks/useFavoriteToggle.ts
+++ b/src/hooks/useFavoriteToggle.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { doc, serverTimestamp, updateDoc } from "firebase/firestore";
+
+import { getFirebaseDb } from "@/lib/firebase";
+import type { ItemRecord } from "@/lib/types";
+
+type UseFavoriteToggleOptions = {
+  onSuccess?: (nextValue: boolean) => void;
+};
+
+export function useFavoriteToggle(
+  item: ItemRecord,
+  options?: UseFavoriteToggleOptions
+) {
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const onSuccess = options?.onSuccess;
+
+  useEffect(() => {
+    if (!error) return;
+    const timer = setTimeout(() => setError(null), 3000);
+    return () => clearTimeout(timer);
+  }, [error]);
+
+  const toggleFavorite = useCallback(async () => {
+    if (pending) return;
+    const db = getFirebaseDb();
+    if (!db) {
+      setError("Firebase 尚未設定");
+      return;
+    }
+    const nextValue = !item.isFavorite;
+    setPending(true);
+    setError(null);
+    try {
+      await updateDoc(doc(db, "item", item.id), {
+        isFavorite: nextValue,
+        updatedAt: serverTimestamp(),
+      });
+      onSuccess?.(nextValue);
+    } catch (err) {
+      console.error("更新最愛狀態時發生錯誤", err);
+      setError("更新最愛狀態時發生錯誤");
+    } finally {
+      setPending(false);
+    }
+  }, [item.id, item.isFavorite, onSuccess, pending]);
+
+  return {
+    toggleFavorite,
+    pending,
+    error,
+    clearError: () => setError(null),
+  };
+}
+

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -82,6 +82,7 @@ export type ItemRecord = {
   links: ItemLink[];
   thumbUrl?: string | null;
   thumbTransform?: ThumbTransform | null;
+  isFavorite: boolean;
   progressNote?: string | null;
   insightNote?: string | null;
   note?: string | null;


### PR DESCRIPTION
## Summary
- add reusable heart toggle component and hook for favorite state updates
- persist the new isFavorite attribute through forms, item pages, and list renders
- expand cabinet filters with favorites-only option and collapsible controls

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbaacfc4408320a73a76868dfcbb23