### PR TITLE
Refine item pages and header navigation

### DIFF
--- a/src/app/cabinet/[id]/page.tsx
+++ b/src/app/cabinet/[id]/page.tsx
@@ -680,6 +680,12 @@ export default function CabinetDetailPage({ params }: CabinetPageProps) {
               標籤管理
             </Link>
             <Link
+              href={`/cabinet/${encodeURIComponent(cabinetId)}/trash`}
+              className={`${buttonClass({ variant: "danger" })} w-full sm:w-auto`}
+            >
+              垃圾桶
+            </Link>
+            <Link
               href={`/cabinet/${encodeURIComponent(cabinetId)}/edit`}
               className={`${buttonClass({ variant: "secondary" })} w-full sm:w-auto`}
             >

--- a/src/app/cabinet/[id]/trash/page.tsx
+++ b/src/app/cabinet/[id]/trash/page.tsx
@@ -1,0 +1,596 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { use, useEffect, useMemo, useState } from "react";
+import { onAuthStateChanged, type User } from "firebase/auth";
+import {
+  collection,
+  deleteDoc,
+  doc,
+  getDoc,
+  getDocs,
+  onSnapshot,
+  query,
+  serverTimestamp,
+  setDoc,
+  Timestamp,
+  where,
+} from "firebase/firestore";
+
+import { getFirebaseAuth, getFirebaseDb } from "@/lib/firebase";
+import { buttonClass } from "@/lib/ui";
+import {
+  DEFAULT_THUMB_TRANSFORM,
+  isOptimizedImageUrl,
+  normalizeThumbTransform,
+} from "@/lib/image-utils";
+import type { ThumbTransform } from "@/lib/types";
+
+type CabinetTrashPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+type TrashListItem = {
+  id: string;
+  title: string;
+  thumbUrl: string | null;
+  thumbTransform: ThumbTransform;
+  deletedAt: Timestamp | null;
+};
+
+type PendingAction = { id: string; type: "restore" | "delete" } | null;
+
+type ProgressSnapshot = {
+  id: string;
+  data: Record<string, unknown>;
+};
+
+type TrashDocData = {
+  uid?: string;
+  cabinetId?: string;
+  itemData?: Record<string, unknown>;
+  progress?: unknown;
+  deletedAt?: Timestamp;
+};
+
+function formatTimestamp(timestamp?: Timestamp | null): string {
+  if (!timestamp) {
+    return "";
+  }
+  const date = timestamp.toDate();
+  const pad = (value: number) => value.toString().padStart(2, "0");
+  return `${date.getFullYear()}/${pad(date.getMonth() + 1)}/${pad(
+    date.getDate()
+  )} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+function parseProgressSnapshots(value: unknown): ProgressSnapshot[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") {
+        return null;
+      }
+      const { id, data } = entry as {
+        id?: unknown;
+        data?: unknown;
+      };
+      if (typeof id !== "string" || !data || typeof data !== "object") {
+        return null;
+      }
+      return { id, data: data as Record<string, unknown> };
+    })
+    .filter((entry): entry is ProgressSnapshot => Boolean(entry));
+}
+
+export default function CabinetTrashPage({ params }: CabinetTrashPageProps) {
+  const { id: cabinetId } = use(params);
+  const [user, setUser] = useState<User | null>(null);
+  const [authChecked, setAuthChecked] = useState(false);
+  const [cabinetName, setCabinetName] = useState("未命名櫃子");
+  const [cabinetLoading, setCabinetLoading] = useState(true);
+  const [cabinetError, setCabinetError] = useState<string | null>(null);
+  const [canView, setCanView] = useState(false);
+  const [items, setItems] = useState<TrashListItem[]>([]);
+  const [itemsLoading, setItemsLoading] = useState(true);
+  const [listError, setListError] = useState<string | null>(null);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<PendingAction>(null);
+  const [clearing, setClearing] = useState(false);
+
+  useEffect(() => {
+    const auth = getFirebaseAuth();
+    if (!auth) {
+      setAuthChecked(true);
+      setCabinetLoading(false);
+      setItemsLoading(false);
+      setCabinetError("Firebase 尚未設定");
+      setListError("Firebase 尚未設定");
+      return undefined;
+    }
+    const unsub = onAuthStateChanged(auth, (current) => {
+      setUser(current);
+      setAuthChecked(true);
+    });
+    return () => unsub();
+  }, []);
+
+  useEffect(() => {
+    if (!user) {
+      setCanView(false);
+      setCabinetName("未命名櫃子");
+      setCabinetError(null);
+      setCabinetLoading(false);
+      return;
+    }
+    const db = getFirebaseDb();
+    if (!db) {
+      setCabinetError("Firebase 尚未設定");
+      setCabinetLoading(false);
+      setCanView(false);
+      return;
+    }
+    setCabinetLoading(true);
+    setCabinetError(null);
+    let active = true;
+    getDoc(doc(db, "cabinet", cabinetId))
+      .then((snap) => {
+        if (!active) return;
+        if (!snap.exists()) {
+          setCabinetError("找不到櫃子");
+          setCanView(false);
+          setCabinetLoading(false);
+          return;
+        }
+        const data = snap.data();
+        if (data?.uid !== user.uid) {
+          setCabinetError("您沒有存取此櫃子的權限");
+          setCanView(false);
+          setCabinetLoading(false);
+          return;
+        }
+        const name =
+          typeof data?.name === "string" && data.name.trim().length > 0
+            ? data.name.trim()
+            : "未命名櫃子";
+        setCabinetName(name);
+        setCanView(true);
+        setCabinetLoading(false);
+      })
+      .catch((err) => {
+        console.error("載入櫃子資訊時發生錯誤", err);
+        if (!active) return;
+        setCabinetError("載入櫃子資訊時發生錯誤");
+        setCanView(false);
+        setCabinetLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [user, cabinetId]);
+
+  useEffect(() => {
+    if (!user || !canView) {
+      setItems([]);
+      setItemsLoading(false);
+      return;
+    }
+    const db = getFirebaseDb();
+    if (!db) {
+      setListError("Firebase 尚未設定");
+      setItems([]);
+      setItemsLoading(false);
+      return;
+    }
+    setItemsLoading(true);
+    setListError(null);
+    const trashQuery = query(
+      collection(db, "cabinetTrash"),
+      where("uid", "==", user.uid),
+      where("cabinetId", "==", cabinetId)
+    );
+    const unsub = onSnapshot(
+      trashQuery,
+      (snapshot) => {
+        const next = snapshot.docs.map((docSnap) => {
+          const raw = (docSnap.data() ?? {}) as TrashDocData;
+          const itemData = raw.itemData ?? {};
+          const title =
+            typeof itemData?.titleZh === "string" && itemData.titleZh.trim()
+              ? itemData.titleZh.trim()
+              : "未命名物件";
+          const thumbUrl =
+            typeof itemData?.thumbUrl === "string" && itemData.thumbUrl.trim()
+              ? itemData.thumbUrl.trim()
+              : null;
+          const thumbTransform =
+            itemData && typeof itemData.thumbTransform === "object"
+              ? normalizeThumbTransform(itemData.thumbTransform)
+              : { ...DEFAULT_THUMB_TRANSFORM };
+          const deletedAt =
+            raw.deletedAt instanceof Timestamp ? raw.deletedAt : null;
+          return {
+            id: docSnap.id,
+            title,
+            thumbUrl,
+            thumbTransform,
+            deletedAt,
+          } satisfies TrashListItem;
+        });
+        next.sort((a, b) => {
+          const left = a.deletedAt ? a.deletedAt.toMillis() : 0;
+          const right = b.deletedAt ? b.deletedAt.toMillis() : 0;
+          return right - left;
+        });
+        setItems(next);
+        setItemsLoading(false);
+        setListError(null);
+      },
+      (error) => {
+        console.error("載入垃圾桶資料時發生錯誤", error);
+        setItems([]);
+        setItemsLoading(false);
+        setListError("載入垃圾桶資料時發生錯誤");
+      }
+    );
+    return () => unsub();
+  }, [user, canView, cabinetId]);
+
+  const headerTitle = useMemo(
+    () => `${cabinetName} 的垃圾桶`,
+    [cabinetName]
+  );
+
+  async function handleRestore(itemId: string) {
+    if (!user) {
+      setActionError("請先登入");
+      return;
+    }
+    if (!canView) {
+      setActionError("您沒有還原此物件的權限");
+      return;
+    }
+    if (pendingAction || clearing) {
+      return;
+    }
+    const db = getFirebaseDb();
+    if (!db) {
+      setActionError("Firebase 尚未設定");
+      return;
+    }
+    setPendingAction({ id: itemId, type: "restore" });
+    setActionError(null);
+    setActionMessage(null);
+    try {
+      const trashRef = doc(db, "cabinetTrash", itemId);
+      const snap = await getDoc(trashRef);
+      if (!snap.exists()) {
+        throw new Error("找不到垃圾桶資料");
+      }
+      const raw = snap.data() as TrashDocData;
+      if (raw.uid !== user.uid || raw.cabinetId !== cabinetId) {
+        throw new Error("您沒有還原此物件的權限");
+      }
+      const itemData = raw.itemData;
+      if (!itemData || typeof itemData !== "object") {
+        throw new Error("原始物件資料不完整，無法還原");
+      }
+      const itemPayload: Record<string, unknown> = {
+        ...(itemData as Record<string, unknown>),
+        updatedAt: serverTimestamp(),
+      };
+      await setDoc(doc(db, "item", itemId), itemPayload);
+      const progressEntries = parseProgressSnapshots(raw.progress);
+      if (progressEntries.length > 0) {
+        await Promise.all(
+          progressEntries.map((entry) =>
+            setDoc(doc(db, "item", itemId, "progress", entry.id), entry.data)
+          )
+        );
+      }
+      await deleteDoc(trashRef);
+      setActionMessage("已還原物件");
+    } catch (err) {
+      console.error("還原垃圾桶物件時發生錯誤", err);
+      setActionError(
+        err instanceof Error && err.message
+          ? err.message
+          : "還原垃圾桶物件時發生錯誤"
+      );
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  async function handlePermanentDelete(itemId: string) {
+    if (!user) {
+      setActionError("請先登入");
+      return;
+    }
+    if (!canView) {
+      setActionError("您沒有刪除此物件的權限");
+      return;
+    }
+    if (!window.confirm("確認永久刪除此物件？操作無法復原。")) {
+      return;
+    }
+    if (pendingAction || clearing) {
+      return;
+    }
+    const db = getFirebaseDb();
+    if (!db) {
+      setActionError("Firebase 尚未設定");
+      return;
+    }
+    setPendingAction({ id: itemId, type: "delete" });
+    setActionError(null);
+    setActionMessage(null);
+    try {
+      const trashRef = doc(db, "cabinetTrash", itemId);
+      const snap = await getDoc(trashRef);
+      if (!snap.exists()) {
+        throw new Error("找不到垃圾桶資料");
+      }
+      const raw = snap.data() as TrashDocData;
+      if (raw.uid !== user.uid || raw.cabinetId !== cabinetId) {
+        throw new Error("您沒有刪除此物件的權限");
+      }
+      await deleteDoc(trashRef);
+      setActionMessage("已永久刪除物件");
+    } catch (err) {
+      console.error("永久刪除垃圾桶物件時發生錯誤", err);
+      setActionError(
+        err instanceof Error && err.message
+          ? err.message
+          : "永久刪除垃圾桶物件時發生錯誤"
+      );
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  async function handleClearTrash() {
+    if (!user) {
+      setActionError("請先登入");
+      return;
+    }
+    if (!canView) {
+      setActionError("您沒有清空垃圾桶的權限");
+      return;
+    }
+    if (!window.confirm("確認清空垃圾桶？此操作無法復原。")) {
+      return;
+    }
+    if (pendingAction || clearing) {
+      return;
+    }
+    const db = getFirebaseDb();
+    if (!db) {
+      setActionError("Firebase 尚未設定");
+      return;
+    }
+    setClearing(true);
+    setActionError(null);
+    setActionMessage(null);
+    try {
+      const trashQuery = query(
+        collection(db, "cabinetTrash"),
+        where("uid", "==", user.uid),
+        where("cabinetId", "==", cabinetId)
+      );
+      const snapshot = await getDocs(trashQuery);
+      await Promise.all(snapshot.docs.map((docSnap) => deleteDoc(docSnap.ref)));
+      setActionMessage("垃圾桶已清空");
+    } catch (err) {
+      console.error("清空垃圾桶時發生錯誤", err);
+      setActionError(
+        err instanceof Error && err.message
+          ? err.message
+          : "清空垃圾桶時發生錯誤"
+      );
+    } finally {
+      setClearing(false);
+    }
+  }
+
+  if (!authChecked) {
+    return (
+      <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+        <div className="mx-auto w-full max-w-2xl rounded-2xl border bg-white/70 p-6 text-base shadow-sm">
+          正在確認登入狀態…
+        </div>
+      </main>
+    );
+  }
+
+  if (!user) {
+    return (
+      <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+        <div className="mx-auto flex w-full max-w-2xl flex-col gap-4 rounded-2xl border bg-white/70 p-6 shadow-sm">
+          <h1 className="text-2xl font-semibold text-gray-900">垃圾桶</h1>
+          <p className="text-base text-gray-600">
+            未登入。請先前往
+            <Link href="/login" className="ml-1 underline">
+              /login
+            </Link>
+            後再查看垃圾桶內容。
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  if (cabinetLoading) {
+    return (
+      <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+        <div className="mx-auto w-full max-w-2xl rounded-2xl border bg-white/70 p-6 text-base shadow-sm">
+          正在載入櫃子資訊…
+        </div>
+      </main>
+    );
+  }
+
+  if (cabinetError || !canView) {
+    return (
+      <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+        <div className="mx-auto flex w-full max-w-2xl flex-col gap-4 rounded-2xl border bg-white/70 p-6 shadow-sm">
+          <h1 className="text-2xl font-semibold text-gray-900">垃圾桶</h1>
+          <div className="rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">
+            {cabinetError ?? "您沒有存取此垃圾桶的權限"}
+          </div>
+          <div>
+            <Link
+              href={`/cabinet/${encodeURIComponent(cabinetId)}`}
+              className={`${buttonClass({ variant: "secondary" })}`}
+            >
+              返回櫃子頁面
+            </Link>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-8">
+        <header className="flex flex-col gap-4 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
+          <div className="space-y-1">
+            <h1 className="break-anywhere text-2xl font-semibold text-gray-900">
+              {headerTitle}
+            </h1>
+            <p className="text-sm text-gray-600">
+              被刪除的物件會暫時保留在此，可在這裡還原或永久刪除。
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2 text-sm sm:flex-row sm:flex-wrap sm:justify-end">
+            <Link
+              href={`/cabinet/${encodeURIComponent(cabinetId)}`}
+              className={`${buttonClass({ variant: "secondary" })} w-full sm:w-auto`}
+            >
+              返回櫃子
+            </Link>
+            <button
+              type="button"
+              onClick={handleClearTrash}
+              disabled={clearing || pendingAction !== null}
+              className={`${buttonClass({ variant: "danger" })} w-full sm:w-auto`}
+            >
+              {clearing ? "清空中…" : "清空垃圾桶"}
+            </button>
+          </div>
+        </header>
+
+        {actionMessage && (
+          <div className="rounded-2xl bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+            {actionMessage}
+          </div>
+        )}
+        {actionError && (
+          <div className="rounded-2xl bg-red-50 px-4 py-3 text-sm text-red-700">
+            {actionError}
+          </div>
+        )}
+        {listError && (
+          <div className="rounded-2xl bg-red-50 px-4 py-3 text-sm text-red-700">
+            {listError}
+          </div>
+        )}
+
+        <section className="rounded-2xl border bg-white/70 p-6 shadow-sm">
+          {itemsLoading ? (
+            <p className="text-sm text-gray-600">正在載入垃圾桶內容…</p>
+          ) : items.length === 0 ? (
+            <div className="rounded-xl border border-dashed bg-white/60 p-6 text-center text-sm text-gray-500">
+              垃圾桶目前是空的。
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {items.map((item) => {
+                const transform = item.thumbTransform ?? DEFAULT_THUMB_TRANSFORM;
+                const thumbStyle = {
+                  transform: `translate(${transform.offsetX}%, ${transform.offsetY}%) scale(${transform.scale})`,
+                  transformOrigin: "center",
+                } as const;
+                const restoring =
+                  pendingAction?.id === item.id && pendingAction.type === "restore";
+                const deleting =
+                  pendingAction?.id === item.id && pendingAction.type === "delete";
+                return (
+                  <article
+                    key={item.id}
+                    className="flex flex-col gap-4 rounded-2xl border border-gray-100 bg-white/90 p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between"
+                  >
+                    <div className="flex items-center gap-4">
+                      <div className="h-20 w-16 overflow-hidden rounded-xl border border-gray-200 bg-gray-100 shadow-inner">
+                        {item.thumbUrl ? (
+                          isOptimizedImageUrl(item.thumbUrl) ? (
+                            <Image
+                              src={item.thumbUrl}
+                              alt={`${item.title} 縮圖`}
+                              fill
+                              sizes="80px"
+                              className="object-cover"
+                              style={thumbStyle}
+                              draggable={false}
+                            />
+                          ) : (
+                            // eslint-disable-next-line @next/next/no-img-element
+                            <img
+                              src={item.thumbUrl}
+                              alt={`${item.title} 縮圖`}
+                              className="h-full w-full select-none object-cover"
+                              style={thumbStyle}
+                              loading="lazy"
+                              draggable={false}
+                            />
+                          )
+                        ) : (
+                          <div className="flex h-full w-full items-center justify-center text-[10px] font-medium text-gray-400">
+                            無縮圖
+                          </div>
+                        )}
+                      </div>
+                      <div className="space-y-1">
+                        <h2 className="break-anywhere text-lg font-semibold text-gray-900">
+                          {item.title}
+                        </h2>
+                        {item.deletedAt && (
+                          <p className="text-xs text-gray-500">
+                            移除於：{formatTimestamp(item.deletedAt)}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                      <button
+                        type="button"
+                        onClick={() => handleRestore(item.id)}
+                        disabled={restoring || deleting || clearing}
+                        className={`${buttonClass({ variant: "secondary" })} w-full sm:w-auto`}
+                      >
+                        {restoring ? "還原中…" : "還原"}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handlePermanentDelete(item.id)}
+                        disabled={restoring || deleting || clearing}
+                        className={`${buttonClass({ variant: "outlineDanger" })} w-full sm:w-auto`}
+                      >
+                        {deleting ? "刪除中…" : "刪除"}
+                      </button>
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,6 +25,144 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
+:root[data-theme="dark"] {
+  --background: #0b1120;
+  --foreground: #e2e8f0;
+}
+
+:root[data-theme="dark"] body {
+  background: var(--background);
+  color: var(--foreground);
+}
+
+:root[data-theme="dark"] .bg-white {
+  background-color: #1f2937 !important;
+}
+
+:root[data-theme="dark"] .bg-white\/60 {
+  background-color: rgba(30, 41, 59, 0.6) !important;
+}
+
+:root[data-theme="dark"] .bg-white\/70 {
+  background-color: rgba(30, 41, 59, 0.7) !important;
+}
+
+:root[data-theme="dark"] .bg-white\/80 {
+  background-color: rgba(30, 41, 59, 0.8) !important;
+}
+
+:root[data-theme="dark"] .bg-white\/90 {
+  background-color: rgba(30, 41, 59, 0.9) !important;
+}
+
+:root[data-theme="dark"] .bg-gray-50 {
+  background-color: #0f172a !important;
+}
+
+:root[data-theme="dark"] .bg-gray-100 {
+  background-color: #1e293b !important;
+}
+
+:root[data-theme="dark"] .bg-gray-200 {
+  background-color: #334155 !important;
+}
+
+:root[data-theme="dark"] .bg-blue-50 {
+  background-color: rgba(59, 130, 246, 0.2) !important;
+}
+
+:root[data-theme="dark"] .bg-blue-50\/40 {
+  background-color: rgba(59, 130, 246, 0.16) !important;
+}
+
+:root[data-theme="dark"] .bg-blue-50\/60 {
+  background-color: rgba(59, 130, 246, 0.24) !important;
+}
+
+:root[data-theme="dark"] .bg-blue-100 {
+  background-color: rgba(59, 130, 246, 0.28) !important;
+}
+
+:root[data-theme="dark"] .bg-emerald-50 {
+  background-color: rgba(16, 185, 129, 0.18) !important;
+}
+
+:root[data-theme="dark"] .bg-red-50 {
+  background-color: rgba(248, 113, 113, 0.2) !important;
+}
+
+:root[data-theme="dark"] .border-gray-100 {
+  border-color: #1e293b !important;
+}
+
+:root[data-theme="dark"] .border-gray-200 {
+  border-color: #334155 !important;
+}
+
+:root[data-theme="dark"] .border-gray-300 {
+  border-color: #475569 !important;
+}
+
+:root[data-theme="dark"] .text-gray-900 {
+  color: #f8fafc !important;
+}
+
+:root[data-theme="dark"] .text-gray-800 {
+  color: #f1f5f9 !important;
+}
+
+:root[data-theme="dark"] .text-gray-700 {
+  color: #e2e8f0 !important;
+}
+
+:root[data-theme="dark"] .text-gray-600 {
+  color: #cbd5f5 !important;
+}
+
+:root[data-theme="dark"] .text-gray-500 {
+  color: #94a3b8 !important;
+}
+
+:root[data-theme="dark"] .text-gray-400 {
+  color: #64748b !important;
+}
+
+:root[data-theme="dark"] .text-blue-800 {
+  color: #bfdbfe !important;
+}
+
+:root[data-theme="dark"] .text-blue-700 {
+  color: #93c5fd !important;
+}
+
+:root[data-theme="dark"] .text-blue-600 {
+  color: #60a5fa !important;
+}
+
+:root[data-theme="dark"] .text-emerald-600 {
+  color: #34d399 !important;
+}
+
+:root[data-theme="dark"] .text-red-700 {
+  color: #fca5a5 !important;
+}
+
+:root[data-theme="dark"] .hover\:bg-gray-100:hover {
+  background-color: #1f2937 !important;
+}
+
+:root[data-theme="dark"] .hover\:bg-blue-50:hover {
+  background-color: rgba(59, 130, 246, 0.28) !important;
+}
+
+:root[data-theme="dark"] .hover\:bg-blue-50\/60:hover {
+  background-color: rgba(59, 130, 246, 0.24) !important;
+}
+
+:root[data-theme="dark"] .hover\:text-blue-700:hover {
+  color: #bfdbfe !important;
+}
+
 @layer utilities {
   .line-clamp-2 {
     display: -webkit-box;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -163,6 +163,28 @@ body {
   color: #bfdbfe !important;
 }
 
+:root[data-theme="dark"] .detail-back-button {
+  background-color: #f1f5f9 !important;
+  border-color: #f1f5f9 !important;
+  color: #0f172a !important;
+}
+
+:root[data-theme="dark"] .detail-back-button:hover {
+  background-color: #e2e8f0 !important;
+  color: #020617 !important;
+}
+
+:root[data-theme="dark"] .detail-action-button {
+  background-color: rgba(148, 163, 184, 0.25) !important;
+  border-color: rgba(148, 163, 184, 0.45) !important;
+  color: #f8fafc !important;
+}
+
+:root[data-theme="dark"] .detail-action-button:hover {
+  background-color: rgba(148, 163, 184, 0.35) !important;
+  color: #ffffff !important;
+}
+
 @layer utilities {
   .line-clamp-2 {
     display: -webkit-box;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -147,6 +147,10 @@ body {
   color: #fca5a5 !important;
 }
 
+:root[data-theme="dark"] .item-form-title {
+  color: #111827 !important;
+}
+
 :root[data-theme="dark"] .hover\:bg-gray-100:hover {
   background-color: #1f2937 !important;
 }

--- a/src/app/item/[id]/page.tsx
+++ b/src/app/item/[id]/page.tsx
@@ -57,6 +57,9 @@ const progressTypeLabelMap = new Map(
   PROGRESS_TYPE_OPTIONS.map((option) => [option.value, option.label])
 );
 
+const backButtonClass =
+  "inline-flex items-center justify-center rounded-xl border border-black bg-white px-4 py-2 text-sm font-medium text-black shadow-sm transition hover:bg-black hover:text-white";
+
 function isOptimizedImageUrl(url?: string | null): boolean {
   if (!url) return false;
   try {
@@ -1047,9 +1050,9 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
             <div className="flex flex-wrap gap-2 text-sm">
               <Link
                 href={`/cabinet/${encodeURIComponent(item.cabinetId)}`}
-                className={buttonClass({ variant: "secondary" })}
+                className={backButtonClass}
               >
-                檢視櫃子
+                上一頁
               </Link>
             </div>
           )}
@@ -1133,9 +1136,9 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
               {item.cabinetId && !cabinetMissing && (
                 <Link
                   href={`/cabinet/${encodeURIComponent(item.cabinetId)}`}
-                  className={`${buttonClass({ variant: "secondary" })} w-full sm:w-auto`}
+                  className={`${backButtonClass} w-full sm:w-auto`}
                 >
-                  檢視櫃子
+                  上一頁
                 </Link>
               )}
               <Link

--- a/src/app/item/[id]/page.tsx
+++ b/src/app/item/[id]/page.tsx
@@ -1087,9 +1087,26 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
 
   return (
     <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
-      <div className="mx-auto flex w-full max-w-4xl flex-col gap-8">
-        <header className="flex flex-col gap-6 rounded-3xl border border-gray-100 bg-white/90 p-6 shadow-sm sm:flex-row sm:flex-wrap sm:items-start sm:justify-between">
-          <div className="space-y-3">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 sm:gap-8">
+        {item.cabinetId && !cabinetMissing ? (
+          <div className="flex justify-end">
+            <Link
+              href={`/cabinet/${encodeURIComponent(item.cabinetId)}`}
+              className={backButtonClass}
+            >
+              上一頁
+            </Link>
+          </div>
+        ) : null}
+        <header className="relative flex flex-col gap-6 rounded-3xl border border-gray-100 bg-white/90 p-6 shadow-sm sm:flex-row sm:flex-wrap sm:items-start sm:justify-between">
+          <FavoriteToggleButton
+            isFavorite={item.isFavorite}
+            onToggle={handleFavoriteToggle}
+            disabled={favoritePending}
+            ariaLabel={favoriteLabel}
+            className="absolute right-6 top-6"
+          />
+          <div className="space-y-3 pr-4 sm:pr-16">
             <h1 className="text-3xl font-semibold text-gray-900">{item.titleZh}</h1>
             {item.titleAlt && <p className="text-base text-gray-500">{item.titleAlt}</p>}
             <div className="flex flex-wrap gap-3 text-sm text-gray-600">
@@ -1113,15 +1130,7 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
               )}
             </div>
           </div>
-          <div className="flex w-full flex-col gap-3 text-sm sm:w-auto sm:min-w-[16rem] sm:flex-none sm:items-end">
-            <div className="flex justify-end">
-              <FavoriteToggleButton
-                isFavorite={item.isFavorite}
-                onToggle={handleFavoriteToggle}
-                disabled={favoritePending}
-                ariaLabel={favoriteLabel}
-              />
-            </div>
+          <div className="flex w-full flex-col gap-3 pt-12 text-sm sm:w-auto sm:min-w-[16rem] sm:flex-none sm:items-end sm:pt-0">
             <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:justify-end">
               {primaryLink && (
                 <a
@@ -1132,14 +1141,6 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
                 >
                   點我觀看
                 </a>
-              )}
-              {item.cabinetId && !cabinetMissing && (
-                <Link
-                  href={`/cabinet/${encodeURIComponent(item.cabinetId)}`}
-                  className={`${backButtonClass} w-full sm:w-auto`}
-                >
-                  上一頁
-                </Link>
               )}
               <Link
                 href={`/item/${encodeURIComponent(item.id)}/edit`}

--- a/src/app/item/quick-add/page.tsx
+++ b/src/app/item/quick-add/page.tsx
@@ -224,6 +224,7 @@ export default function QuickAddItemPage() {
         thumbUrl: resolvedThumbUrl || null,
         thumbTransform: null,
         progressNote: null,
+        insightNotes: [],
         insightNote: null,
         note: null,
         appearances: [],

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -99,6 +99,31 @@ export default function AppHeader() {
           Entertainment Locker
         </Link>
         <div className="flex items-center gap-4">
+          <div className="flex items-center gap-3 text-sm text-gray-600">
+            {user ? (
+              <>
+                {user.email && (
+                  <span className="hidden truncate max-w-[12rem] sm:inline">
+                    {user.email}
+                  </span>
+                )}
+                <button
+                  type="button"
+                  onClick={handleSignOut}
+                  disabled={signingOut}
+                  className={actionButtonClass}
+                >
+                  {signingOut ? "登出中…" : "登出"}
+                </button>
+              </>
+            ) : authReady ? (
+              <Link href="/login" className={actionButtonClass}>
+                登入 / 註冊
+              </Link>
+            ) : (
+              <span>…</span>
+            )}
+          </div>
           <div className="relative" ref={menuRef}>
             <button
               type="button"
@@ -144,31 +169,6 @@ export default function AppHeader() {
                 </ul>
               </nav>
             ) : null}
-          </div>
-          <div className="flex items-center gap-3 text-sm text-gray-600">
-          {user ? (
-            <>
-              {user.email && (
-                <span className="hidden truncate max-w-[12rem] sm:inline">
-                  {user.email}
-                </span>
-              )}
-              <button
-                type="button"
-                onClick={handleSignOut}
-                disabled={signingOut}
-                className={actionButtonClass}
-              >
-                {signingOut ? "登出中…" : "登出"}
-              </button>
-            </>
-          ) : authReady ? (
-            <Link href="/login" className={actionButtonClass}>
-              登入 / 註冊
-            </Link>
-          ) : (
-            <span>…</span>
-          )}
           </div>
         </div>
       </div>

--- a/src/components/ItemForm.tsx
+++ b/src/components/ItemForm.tsx
@@ -663,7 +663,9 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
   if (!user) {
     return (
       <main className="min-h-[100dvh] p-6 space-y-4">
-        <h1 className="text-2xl font-semibold">{mode === "edit" ? "編輯物件" : "新增物件"}</h1>
+        <h1 className="item-form-title text-2xl font-semibold text-gray-900">
+          {mode === "edit" ? "編輯物件" : "新增物件"}
+        </h1>
         <p className="text-base">
           未登入。請前往
           <a href="/login" className="ml-1 underline">
@@ -906,7 +908,9 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
       return;
     }
     if (
-      !window.confirm("確認刪除此物件？會一併刪除相關進度資料，且無法復原。")
+      !window.confirm(
+        "確認將此物件移至垃圾桶？相關進度會一併移動，可於垃圾桶還原或永久刪除。"
+      )
     ) {
       return;
     }
@@ -1235,7 +1239,7 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
         <section className="space-y-6">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div className="space-y-2">
-              <h1 className="text-2xl font-semibold text-gray-900">
+              <h1 className="item-form-title text-2xl font-semibold text-gray-900">
                 {mode === "edit" ? "編輯物件" : "新增物件"}
               </h1>
               <p className="text-sm text-gray-500">
@@ -2049,7 +2053,7 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
               contentClass="space-y-4"
             >
               <p className="text-sm text-red-600">
-                刪除後將移除此物件及所有進度記錄，操作無法復原。
+                刪除後會將此物件與進度移至櫃子垃圾桶，可在垃圾桶還原或永久刪除。
               </p>
               {deleteError && (
                 <div className="rounded-xl bg-red-100 px-4 py-3 text-sm text-red-700">

--- a/src/components/ItemForm.tsx
+++ b/src/components/ItemForm.tsx
@@ -91,6 +91,19 @@ type SectionKey =
   | "progressManager"
   | "dangerZone";
 
+function createSectionState(allOpen: boolean): Record<SectionKey, boolean> {
+  return {
+    basic: allOpen,
+    links: allOpen,
+    mediaNotes: allOpen,
+    appearances: allOpen,
+    insight: allOpen,
+    status: allOpen,
+    progressManager: allOpen,
+    dangerZone: allOpen,
+  };
+}
+
 function generateLocalId(): string {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
     return crypto.randomUUID();
@@ -220,19 +233,11 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
   );
   const tagsCacheRef = useRef<Record<string, string[]>>({});
   const draggingAppearanceIndexRef = useRef<number | null>(null);
-  const [sectionOpen, setSectionOpen] = useState<Record<SectionKey, boolean>>({
-    basic: true,
-    links: true,
-    mediaNotes: true,
-    appearances: true,
-    insight: true,
-    status: true,
-    progressManager: true,
-    dangerZone: true,
-  });
-  const previousCabinetIdRef = useRef<string | null>(null);
-
   const mode = itemId ? "edit" : "create";
+  const [sectionOpen, setSectionOpen] = useState<Record<SectionKey, boolean>>(() =>
+    createSectionState(mode === "create")
+  );
+  const previousCabinetIdRef = useRef<string | null>(null);
 
   const fetchCabinetTags = useCallback(
     async (cabinetId: string, force = false): Promise<string[]> => {
@@ -809,6 +814,7 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
     } catch (err) {
       if (err instanceof ValidationError) {
         setError(err.message);
+        setSectionOpen(createSectionState(true));
       } else if (err instanceof Error && err.message) {
         setError(err.message);
       } else {

--- a/src/components/ProgressEditor.tsx
+++ b/src/components/ProgressEditor.tsx
@@ -149,7 +149,7 @@ function ProgressFields({ state, onChange, disabled }: ProgressFieldsProps) {
           <input
             type="number"
             inputMode="decimal"
-            step="0.1"
+            step="1"
             value={state.value}
             onChange={(event) => onChange("value", event.target.value)}
             className="h-12 w-full rounded-xl border px-4 text-base"

--- a/src/components/ThumbEditorDialog.tsx
+++ b/src/components/ThumbEditorDialog.tsx
@@ -204,7 +204,7 @@ export default function ThumbEditorDialog({
                   height: "100%",
                   transform: `translate(${local.offsetX}%, ${local.offsetY}%) scale(${local.scale})`,
                   transformOrigin: "center",
-                  objectFit: "cover",
+                  objectFit: "contain",
                 }}
                 draggable={false}
                 onLoad={() => {

--- a/src/components/ThumbEditorDialog.tsx
+++ b/src/components/ThumbEditorDialog.tsx
@@ -156,7 +156,7 @@ export default function ThumbEditorDialog({
       onClick={onClose}
     >
       <div
-        className="w-full max-w-2xl rounded-3xl bg-white p-6 shadow-2xl"
+        className="w-full max-w-xl max-h-[90vh] space-y-5 overflow-y-auto rounded-3xl bg-white p-6 shadow-2xl"
         onClick={(event) => event.stopPropagation()}
       >
         <div className="flex items-start justify-between gap-3">

--- a/src/lib/insights.ts
+++ b/src/lib/insights.ts
@@ -1,0 +1,45 @@
+import type { InsightRecord } from "./types";
+
+export type InsightEntry = {
+  title: string;
+  content: string;
+};
+
+export function normalizeInsightEntries(value: unknown): InsightEntry[] {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? [{ title: "", content: trimmed }] : [];
+  }
+
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const entries: InsightEntry[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+    const record = item as InsightRecord;
+    const title = typeof record.title === "string" ? record.title.trim() : "";
+    const content =
+      typeof record.content === "string" ? record.content.trim() : "";
+    if (!title && !content) {
+      continue;
+    }
+    entries.push({ title, content });
+  }
+
+  return entries;
+}
+
+export function buildInsightStorageList(
+  entries: InsightEntry[]
+): InsightRecord[] {
+  return entries
+    .map((entry) => ({
+      title: entry.title.trim() || null,
+      content: entry.content.trim() || null,
+    }))
+    .filter((entry) => entry.title !== null || entry.content !== null);
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -41,6 +41,8 @@ export const PROGRESS_TYPE_VALUES = [
   "percent",
   "page",
   "level",
+  "season",
+  "part",
 ] as const;
 
 export type ProgressType = (typeof PROGRESS_TYPE_VALUES)[number];
@@ -52,6 +54,8 @@ export const PROGRESS_TYPE_OPTIONS: { value: ProgressType; label: string }[] = [
   { value: "percent", label: "百分比" },
   { value: "page", label: "頁數" },
   { value: "level", label: "等級" },
+  { value: "season", label: "季" },
+  { value: "part", label: "部" },
 ];
 
 export type ThumbTransform = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -79,6 +79,11 @@ export type AppearanceRecord = {
   note?: string | null;
 };
 
+export type InsightRecord = {
+  title?: string | null;
+  content?: string | null;
+};
+
 export type ItemRecord = {
   id: string;
   uid: string;
@@ -93,6 +98,7 @@ export type ItemRecord = {
   isFavorite: boolean;
   progressNote?: string | null;
   insightNote?: string | null;
+  insightNotes?: InsightRecord[];
   note?: string | null;
   appearances: AppearanceRecord[];
   rating?: number | null;

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -34,6 +34,16 @@ export type AppearanceFormData = {
   note?: string;
 };
 
+export type InsightNoteFormInput = {
+  title?: string | undefined;
+  content?: string | undefined;
+};
+
+export type InsightNoteFormData = {
+  title: string;
+  content: string;
+};
+
 export type ItemFormInput = {
   cabinetId: string;
   titleZh: string;
@@ -45,6 +55,7 @@ export type ItemFormInput = {
   thumbTransform?: ThumbTransform | undefined;
   progressNote?: string | undefined;
   insightNote?: string | undefined;
+  insightNotes?: InsightNoteFormInput[] | undefined;
   note?: string | undefined;
   appearances?: AppearanceFormInput[] | undefined;
   rating?: number | null | undefined;
@@ -63,7 +74,7 @@ export type ItemFormData = {
   thumbUrl?: string;
   thumbTransform: ThumbTransform;
   progressNote?: string;
-  insightNote?: string;
+  insightNotes: InsightNoteFormData[];
   note?: string;
   appearances: AppearanceFormData[];
   rating?: number;
@@ -157,6 +168,7 @@ export function parseItemForm(input: ItemFormInput): ItemFormData {
     updateFrequency,
     tags: [],
     links: [],
+    insightNotes: [],
     appearances: [],
     thumbTransform: { ...DEFAULT_THUMB_TRANSFORM },
   };
@@ -246,10 +258,30 @@ export function parseItemForm(input: ItemFormInput): ItemFormData {
     }
   }
 
-  if (input.insightNote) {
+  if (input.insightNotes) {
+    if (!Array.isArray(input.insightNotes)) {
+      throw new ValidationError("心得/筆記格式錯誤");
+    }
+    const notes: InsightNoteFormData[] = [];
+    input.insightNotes.forEach((entry) => {
+      if (!entry) {
+        return;
+      }
+      const record = entry as InsightNoteFormInput;
+      const title =
+        typeof record.title === "string" ? record.title.trim() : "";
+      const content =
+        typeof record.content === "string" ? record.content.trim() : "";
+      if (!title && !content) {
+        return;
+      }
+      notes.push({ title, content });
+    });
+    data.insightNotes = notes;
+  } else if (input.insightNote) {
     const insightNote = assertString(input.insightNote, "心得/筆記格式錯誤").trim();
     if (insightNote) {
-      data.insightNote = insightNote;
+      data.insightNotes = [{ title: "", content: insightNote }];
     }
   }
 


### PR DESCRIPTION
## Summary
- collapse all sections by default when editing an item while keeping creation expanded
- restyle the cabinet button on the item detail page to appear as a prominent back action
- replace the header link list with a hamburger menu and close it on navigation or outside clicks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc9e3e34ac832093991953f38f2218