### PR TITLE
Add language selection to item basic info

### DIFF
--- a/src/app/item/quick-add/page.tsx
+++ b/src/app/item/quick-add/page.tsx
@@ -339,6 +339,7 @@ export default function QuickAddItemPage() {
         titleZh,
         titleAlt: null,
         author: null,
+        language: null,
         tags: [],
         links,
         thumbUrl: resolvedThumbUrl || null,

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -10,6 +10,7 @@ import { useFavoriteToggle } from "@/hooks/useFavoriteToggle";
 import { usePrimaryProgress } from "@/hooks/usePrimaryProgress";
 import { DEFAULT_THUMB_TRANSFORM, isOptimizedImageUrl } from "@/lib/image-utils";
 import {
+  ITEM_LANGUAGE_OPTIONS,
   ITEM_STATUS_OPTIONS,
   UPDATE_FREQUENCY_OPTIONS,
   type ItemRecord,
@@ -19,6 +20,10 @@ import { highlightMatches } from "@/lib/highlight";
 
 const statusLabelMap = new Map(
   ITEM_STATUS_OPTIONS.map((option) => [option.value, option.label])
+);
+
+const languageLabelMap = new Map(
+  ITEM_LANGUAGE_OPTIONS.map((option) => [option.value, option.label])
 );
 
 const updateFrequencyLabelMap = new Map(
@@ -93,6 +98,9 @@ export default function ItemCard({ item, searchTerm = "" }: ItemCardProps) {
     : "未設定";
   const authorDisplay =
     item.author && item.author.trim().length > 0 ? item.author : "未設定";
+  const languageDisplay = item.language
+    ? languageLabelMap.get(item.language) ?? item.language
+    : "未設定";
   const updateFrequencyLabel = item.updateFrequency
     ? updateFrequencyLabelMap.get(item.updateFrequency) ?? item.updateFrequency
     : "未設定";
@@ -229,6 +237,12 @@ export default function ItemCard({ item, searchTerm = "" }: ItemCardProps) {
           <div className="text-xs text-gray-500">作者 / 製作</div>
           <div className="line-clamp-2 break-anywhere font-medium text-gray-900" title={authorDisplay}>
             {highlightMatches(authorDisplay, searchTerm)}
+          </div>
+        </div>
+        <div className="space-y-1">
+          <div className="text-xs text-gray-500">語言</div>
+          <div className="line-clamp-2 break-anywhere font-medium text-gray-900" title={languageDisplay}>
+            {languageDisplay}
           </div>
         </div>
         </div>

--- a/src/components/ItemForm.tsx
+++ b/src/components/ItemForm.tsx
@@ -31,10 +31,13 @@ import CabinetTagQuickEditor from "./CabinetTagQuickEditor";
 import ProgressEditor from "./ProgressEditor";
 import { buttonClass } from "@/lib/ui";
 import {
+  ITEM_LANGUAGE_OPTIONS,
+  ITEM_LANGUAGE_VALUES,
   ITEM_STATUS_OPTIONS,
   ITEM_STATUS_VALUES,
   UPDATE_FREQUENCY_OPTIONS,
   UPDATE_FREQUENCY_VALUES,
+  type ItemLanguage,
   type ItemStatus,
   type ThumbTransform,
   type UpdateFrequency,
@@ -186,6 +189,7 @@ type ItemFormState = {
   titleZh: string;
   titleAlt: string;
   author: string;
+  language: ItemLanguage | "";
   selectedTags: string[];
   progressNote: string;
   note: string;
@@ -208,6 +212,7 @@ function createDefaultState(initialCabinetId?: string): ItemFormState {
     titleZh: "",
     titleAlt: "",
     author: "",
+    language: "",
     selectedTags: [],
     progressNote: "",
     note: "",
@@ -399,6 +404,11 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
           )
             ? (data.updateFrequency as UpdateFrequency)
             : "";
+        const language =
+          typeof data.language === "string" &&
+          ITEM_LANGUAGE_VALUES.includes(data.language as ItemLanguage)
+            ? (data.language as ItemLanguage)
+            : "";
         const ratingValue =
           typeof data.rating === "number" && Number.isFinite(data.rating)
             ? String(data.rating)
@@ -426,6 +436,7 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
           titleZh: (data.titleZh as string) ?? "",
           titleAlt: (data.titleAlt as string) ?? "",
           author: (data.author as string) ?? "",
+          language,
           selectedTags: loadedTags,
           progressNote: (data.progressNote as string) ?? "",
           note: (data.note as string) ?? "",
@@ -754,6 +765,7 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
         titleZh: form.titleZh,
         titleAlt: form.titleAlt,
         author: form.author,
+        language: form.language,
         tags,
         links: filteredLinks,
         thumbUrl: form.thumbUrl,
@@ -789,6 +801,7 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
         titleZh: parsedData.titleZh,
         titleAlt: parsedData.titleAlt ?? null,
         author: parsedData.author ?? null,
+        language: parsedData.language ?? null,
         tags: parsedData.tags,
         links: parsedData.links,
         thumbUrl: resolvedThumbUrl ?? null,
@@ -849,6 +862,7 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
         titleZh: parsedData.titleZh,
         titleAlt: parsedData.titleAlt ?? "",
         author: parsedData.author ?? "",
+        language: parsedData.language ?? "",
         selectedTags: parsedData.tags,
         progressNote: parsedData.progressNote ?? "",
         note: parsedData.note ?? "",
@@ -1344,6 +1358,26 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
                     placeholder="選填"
                     className={inputClass}
                   />
+                </label>
+                <label className="space-y-1">
+                  <span className="text-base">語言</span>
+                  <select
+                    value={form.language}
+                    onChange={(event) =>
+                      setForm((prev) => ({
+                        ...prev,
+                        language: event.target.value as ItemLanguage | "",
+                      }))
+                    }
+                    className={inputClass}
+                  >
+                    <option value="">未選擇</option>
+                    {ITEM_LANGUAGE_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
                 </label>
               </div>
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -18,6 +18,17 @@ export const ITEM_STATUS_OPTIONS: { value: ItemStatus; label: string }[] = [
   { value: "dropped", label: "棄追" },
 ];
 
+export const ITEM_LANGUAGE_VALUES = ["zh", "ja", "en", "ko"] as const;
+
+export type ItemLanguage = (typeof ITEM_LANGUAGE_VALUES)[number];
+
+export const ITEM_LANGUAGE_OPTIONS: { value: ItemLanguage; label: string }[] = [
+  { value: "zh", label: "中文" },
+  { value: "ja", label: "日文" },
+  { value: "en", label: "英文" },
+  { value: "ko", label: "韓文" },
+];
+
 export const UPDATE_FREQUENCY_VALUES = [
   "weekly",
   "biweekly",
@@ -91,6 +102,7 @@ export type ItemRecord = {
   titleZh: string;
   titleAlt?: string | null;
   author?: string | null;
+  language?: ItemLanguage | null;
   tags: string[];
   links: ItemLink[];
   thumbUrl?: string | null;

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -1,8 +1,10 @@
 import {
+  ITEM_LANGUAGE_VALUES,
   ITEM_STATUS_VALUES,
   PROGRESS_TYPE_VALUES,
   UPDATE_FREQUENCY_VALUES,
   type ItemLink,
+  type ItemLanguage,
   type ItemStatus,
   type ProgressType,
   type ThumbTransform,
@@ -49,6 +51,7 @@ export type ItemFormInput = {
   titleZh: string;
   titleAlt?: string | undefined;
   author?: string | undefined;
+  language?: string | undefined;
   tags?: string[] | undefined;
   links?: ItemLink[] | undefined;
   thumbUrl?: string | undefined;
@@ -69,6 +72,7 @@ export type ItemFormData = {
   titleZh: string;
   titleAlt?: string;
   author?: string;
+  language?: ItemLanguage;
   tags: string[];
   links: ItemLink[];
   thumbUrl?: string;
@@ -184,6 +188,16 @@ export function parseItemForm(input: ItemFormInput): ItemFormData {
     const author = assertString(input.author, "作者格式錯誤").trim();
     if (author) {
       data.author = author;
+    }
+  }
+
+  if (input.language !== undefined) {
+    const language = assertString(input.language, "語言格式錯誤").trim();
+    if (language) {
+      if (!ITEM_LANGUAGE_VALUES.includes(language as ItemLanguage)) {
+        throw new ValidationError("語言值不在允許範圍");
+      }
+      data.language = language as ItemLanguage;
     }
   }
 


### PR DESCRIPTION
## Summary
- add language metadata options and expose constants for item records
- update item creation and detail experiences with a language dropdown and display
- extend cabinet filters and quick add flow to handle the new language field

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0cd382bb0832090837e233d5554c1