### PR TITLE
Refactor cabinets management UI

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -20,6 +20,7 @@ service cloud.firestore {
         && isNonEmptyString(data.title, 100)
         && isNonEmptyString(data.content, 60000)
         && ("description" in data ? isOptionalString(data.description, 300) : true)
+        && ("isFavorite" in data ? data.isFavorite is bool : true)
         && isTimestamp(data.createdAt)
         && isTimestamp(data.updatedAt);
     }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,84 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function authed() { return request.auth != null; }
+
+    function isNonEmptyString(field, maxLen) {
+      return field is string && field.size() >= 1 && field.size() <= maxLen;
+    }
+
+    function isOptionalString(field, maxLen) {
+      return field == null || (field is string && field.size() <= maxLen);
+    }
+
+    function isTimestamp(value) {
+      return value is timestamp;
+    }
+
+    function isValidNoteData(data) {
+      return data.uid is string
+        && isNonEmptyString(data.title, 100)
+        && isNonEmptyString(data.content, 60000)
+        && ("description" in data ? isOptionalString(data.description, 300) : true)
+        && isTimestamp(data.createdAt)
+        && isTimestamp(data.updatedAt);
+    }
+
+    // 櫃子
+    match /cabinet/{id} {
+      allow read: if authed() && resource.data.uid == request.auth.uid;
+      allow create: if authed() && request.resource.data.uid == request.auth.uid;
+      allow update, delete: if authed() && resource.data.uid == request.auth.uid;
+    }
+
+    // 物件
+    match /item/{id} {
+      allow read: if authed() && resource.data.uid == request.auth.uid;
+      allow create: if authed() && request.resource.data.uid == request.auth.uid;
+      allow update, delete: if authed() && resource.data.uid == request.auth.uid;
+
+      // 進度（不需要在子文件存 uid，改查父 item 的 uid）
+      match /progress/{pid} {
+        allow read, create, update, delete:
+          if authed() &&
+             get(/databases/$(database)/documents/item/$(id)).data.uid == request.auth.uid;
+      }
+    }
+
+    // 垃圾桶
+    match /cabinetTrash/{itemId} {
+      allow read: if authed() && resource.data.uid == request.auth.uid;
+      allow create: if authed() && request.resource.data.uid == request.auth.uid;
+      allow update: if authed() &&
+                     resource.data.uid == request.auth.uid &&
+                     request.resource.data.uid == request.auth.uid;
+      allow delete: if authed() && resource.data.uid == request.auth.uid;
+    }
+
+    // 標籤
+    match /tag/{id} {
+      allow read: if authed() && resource.data.uid == request.auth.uid;
+      allow create: if authed() && request.resource.data.uid == request.auth.uid;
+      allow update, delete: if authed() && resource.data.uid == request.auth.uid;
+    }
+
+    // 筆記本
+    match /note/{id} {
+      allow read: if authed() && resource.data.uid == request.auth.uid;
+      allow create: if authed()
+                    && request.resource.data.uid == request.auth.uid
+                    && isValidNoteData(request.resource.data);
+      allow update: if authed()
+                    && resource.data.uid == request.auth.uid
+                    && request.resource.data.uid == request.auth.uid
+                    && isValidNoteData(request.resource.data)
+                    && request.resource.data.createdAt == resource.data.createdAt;
+      allow delete: if authed() && resource.data.uid == request.auth.uid;
+    }
+
+    // 使用者偏好
+    match /user/{uid} {
+      allow read, write: if authed() && request.auth.uid == uid;
+    }
+  }
+}

--- a/src/app/cabinets/new/page.tsx
+++ b/src/app/cabinets/new/page.tsx
@@ -4,16 +4,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { FormEvent, useEffect, useState } from "react";
 import { onAuthStateChanged, type User } from "firebase/auth";
-import {
-  addDoc,
-  collection,
-  getDocs,
-  limit,
-  orderBy,
-  query,
-  serverTimestamp,
-  where,
-} from "firebase/firestore";
+import { addDoc, collection, serverTimestamp } from "firebase/firestore";
 
 import { invalidateCabinetOptions } from "@/lib/cabinet-options";
 import { getFirebaseAuth, getFirebaseDb } from "@/lib/firebase";
@@ -66,21 +57,6 @@ export default function NewCabinetPage() {
     setFeedback(null);
     try {
       const cabinetsRef = collection(db, "cabinet");
-      const orderSnap = await getDocs(
-        query(
-          cabinetsRef,
-          where("uid", "==", user.uid),
-          orderBy("order", "desc"),
-          limit(1)
-        )
-      );
-      let highestOrder = 0;
-      orderSnap.forEach((docSnap) => {
-        const data = docSnap.data();
-        if (typeof data?.order === "number" && data.order > highestOrder) {
-          highestOrder = data.order;
-        }
-      });
       const trimmedNote = note.trim();
       await addDoc(cabinetsRef, {
         uid: user.uid,
@@ -89,7 +65,7 @@ export default function NewCabinetPage() {
         createdAt: serverTimestamp(),
         updatedAt: serverTimestamp(),
         tags: [],
-        order: highestOrder + 1,
+        order: Date.now(),
         thumbUrl: null,
         thumbTransform: null,
         isLocked: false,

--- a/src/app/cabinets/new/page.tsx
+++ b/src/app/cabinets/new/page.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { FormEvent, useEffect, useState } from "react";
+import { onAuthStateChanged, type User } from "firebase/auth";
+import {
+  addDoc,
+  collection,
+  getDocs,
+  limit,
+  orderBy,
+  query,
+  serverTimestamp,
+  where,
+} from "firebase/firestore";
+
+import { invalidateCabinetOptions } from "@/lib/cabinet-options";
+import { getFirebaseAuth, getFirebaseDb } from "@/lib/firebase";
+import { buttonClass } from "@/lib/ui";
+
+type Feedback = {
+  type: "error" | "success";
+  message: string;
+};
+
+export default function NewCabinetPage() {
+  const router = useRouter();
+  const [user, setUser] = useState<User | null>(null);
+  const [authChecked, setAuthChecked] = useState(false);
+  const [name, setName] = useState("");
+  const [note, setNote] = useState("");
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    const auth = getFirebaseAuth();
+    if (!auth) {
+      setAuthChecked(true);
+      return undefined;
+    }
+    const unAuth = onAuthStateChanged(auth, (current) => {
+      setUser(current);
+      setAuthChecked(true);
+    });
+    return () => unAuth();
+  }, []);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!user) {
+      setFeedback({ type: "error", message: "請先登入" });
+      return;
+    }
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setFeedback({ type: "error", message: "名稱不可為空" });
+      return;
+    }
+    const db = getFirebaseDb();
+    if (!db) {
+      setFeedback({ type: "error", message: "Firebase 尚未設定" });
+      return;
+    }
+    setSaving(true);
+    setFeedback(null);
+    try {
+      const cabinetsRef = collection(db, "cabinet");
+      const orderSnap = await getDocs(
+        query(
+          cabinetsRef,
+          where("uid", "==", user.uid),
+          orderBy("order", "desc"),
+          limit(1)
+        )
+      );
+      let highestOrder = 0;
+      orderSnap.forEach((docSnap) => {
+        const data = docSnap.data();
+        if (typeof data?.order === "number" && data.order > highestOrder) {
+          highestOrder = data.order;
+        }
+      });
+      const trimmedNote = note.trim();
+      await addDoc(cabinetsRef, {
+        uid: user.uid,
+        name: trimmedName,
+        note: trimmedNote ? trimmedNote : null,
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+        tags: [],
+        order: highestOrder + 1,
+        thumbUrl: null,
+        thumbTransform: null,
+        isLocked: false,
+        isFavorite: false,
+      });
+      invalidateCabinetOptions(user.uid);
+      setFeedback({ type: "success", message: "已新增櫃子" });
+      setName("");
+      setNote("");
+      router.replace("/cabinets");
+    } catch (err) {
+      console.error("新增櫃子時發生錯誤", err);
+      setFeedback({ type: "error", message: "新增櫃子時發生錯誤" });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!authChecked) {
+    return (
+      <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+        <div className="mx-auto w-full max-w-2xl rounded-2xl border bg-white/70 p-6 text-base shadow-sm">
+          正在確認登入狀態…
+        </div>
+      </main>
+    );
+  }
+
+  if (!user) {
+    return (
+      <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+        <div className="mx-auto flex w-full max-w-2xl flex-col gap-4 rounded-2xl border bg-white/70 p-6 shadow-sm">
+          <h1 className="text-2xl font-semibold text-gray-900">新增櫃子</h1>
+          <p className="text-base text-gray-600">
+            未登入。請前往
+            <Link href="/login" className="ml-1 underline">
+              /login
+            </Link>
+            以管理櫃子，或回到
+            <Link href="/" className="ml-1 underline">
+              首頁
+            </Link>
+            了解更多功能。
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+      <div className="mx-auto w-full max-w-2xl space-y-6">
+        <header className="space-y-2">
+          <h1 className="text-2xl font-semibold text-gray-900">新增櫃子</h1>
+          <p className="text-sm text-gray-500">
+            建立新的作品分類，並補充備註方便日後整理。
+          </p>
+        </header>
+        <section className="rounded-2xl border bg-white/70 p-6 shadow-sm">
+          <form className="space-y-6" onSubmit={handleSubmit}>
+            <label className="block space-y-2">
+              <span className="text-sm font-medium text-gray-700">標題</span>
+              <input
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder="例如：漫畫、小說、遊戲"
+                className="h-12 w-full rounded-xl border px-4 text-base"
+                autoFocus
+              />
+            </label>
+            <label className="block space-y-2">
+              <span className="text-sm font-medium text-gray-700">備註</span>
+              <textarea
+                value={note}
+                onChange={(event) => setNote(event.target.value)}
+                placeholder="補充這個櫃子的用途或整理方式"
+                className="min-h-[140px] w-full resize-y rounded-xl border px-4 py-3 text-base"
+              />
+            </label>
+            {feedback && (
+              <div
+                className={
+                  feedback.type === "error"
+                    ? "break-anywhere rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700"
+                    : "break-anywhere rounded-xl bg-emerald-50 px-4 py-3 text-sm text-emerald-700"
+                }
+              >
+                {feedback.message}
+              </div>
+            )}
+            <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+              <Link
+                href="/cabinets"
+                className={`${buttonClass({ variant: "secondary" })} w-full sm:w-auto`}
+              >
+                取消
+              </Link>
+              <button
+                type="submit"
+                disabled={saving}
+                className={`${buttonClass({ variant: "primary" })} w-full sm:w-auto disabled:cursor-not-allowed disabled:opacity-60`}
+              >
+                {saving ? "建立中…" : "建立櫃子"}
+              </button>
+            </div>
+          </form>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/cabinets/page.tsx
+++ b/src/app/cabinets/page.tsx
@@ -55,6 +55,12 @@ type SortOption = "custom" | "recentUpdated" | "created" | "name";
 type SortDirection = "asc" | "desc";
 type DisplayMode = "detailed" | "compact" | "list";
 
+const DISPLAY_MODE_OPTIONS: { value: DisplayMode; label: string }[] = [
+  { value: "detailed", label: "詳細" },
+  { value: "compact", label: "簡略" },
+  { value: "list", label: "列表" },
+];
+
 export default function CabinetsPage() {
   const [user, setUser] = useState<User | null>(null);
   const [authChecked, setAuthChecked] = useState(false);
@@ -580,20 +586,29 @@ export default function CabinetsPage() {
                   />
                   收藏
                 </label>
-                <label className="flex flex-1 flex-col space-y-1">
+                <div className="flex flex-1 flex-col space-y-1">
                   <span className="text-sm text-gray-600">顯示方式</span>
-                  <select
-                    value={displayMode}
-                    onChange={(event) =>
-                      setDisplayMode(event.target.value as DisplayMode)
-                    }
-                    className="h-12 w-full rounded-xl border bg-white px-4 text-base"
-                  >
-                    <option value="detailed">詳細</option>
-                    <option value="compact">簡略</option>
-                    <option value="list">列表</option>
-                  </select>
-                </label>
+                  <div className="flex overflow-hidden rounded-full border border-gray-200 bg-white">
+                    {DISPLAY_MODE_OPTIONS.map((option) => {
+                      const isActive = displayMode === option.value;
+                      return (
+                        <button
+                          key={option.value}
+                          type="button"
+                          onClick={() => setDisplayMode(option.value)}
+                          className={`flex-1 px-4 py-2 text-sm font-medium transition ${
+                            isActive
+                              ? "bg-gray-900 text-white shadow-sm"
+                              : "text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+                          }`}
+                          aria-pressed={isActive}
+                        >
+                          {option.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
               </div>
             </div>
           )}
@@ -698,17 +713,17 @@ export default function CabinetsPage() {
                                 )}
                               </div>
                             </div>
-                            <div className="flex flex-col gap-2 text-sm sm:w-auto sm:flex-row sm:flex-wrap">
+                            <div className="flex flex-col gap-2 text-sm sm:flex-none sm:flex-row sm:flex-wrap sm:justify-end">
                               <button
                                 type="button"
                                 onClick={() => toggleFavorite(row)}
-                                className={`${buttonClass({ variant: "secondary" })} w-full sm:w-auto`}
+                                className={`${buttonClass({ variant: "secondary" })} w-full whitespace-nowrap sm:w-auto`}
                               >
                                 {row.isFavorite ? "取消收藏" : "加入收藏"}
                               </button>
                               {isLocked ? (
                                 <span
-                                  className={`${buttonClass({ variant: "secondary" })} w-full cursor-not-allowed opacity-60 sm:w-auto`}
+                                  className={`${buttonClass({ variant: "secondary" })} w-full cursor-not-allowed whitespace-nowrap opacity-60 sm:w-auto`}
                                   aria-disabled="true"
                                 >
                                   已鎖定
@@ -716,14 +731,14 @@ export default function CabinetsPage() {
                               ) : (
                                 <Link
                                   href={`/cabinet/${encodedId}`}
-                                  className={`${buttonClass({ variant: "secondary" })} w-full sm:w-auto`}
+                                  className={`${buttonClass({ variant: "secondary" })} w-full whitespace-nowrap sm:w-auto`}
                                 >
                                   查看物件
                                 </Link>
                               )}
                               <Link
                                 href={`/cabinet/${encodedId}/edit`}
-                                className={`${buttonClass({ variant: "secondary" })} w-full sm:w-auto`}
+                                className={`${buttonClass({ variant: "secondary" })} w-full whitespace-nowrap sm:w-auto`}
                               >
                                 編輯櫃子
                               </Link>
@@ -745,7 +760,7 @@ export default function CabinetsPage() {
                           className="rounded-2xl border bg-white/70 p-4 shadow-sm"
                         >
                           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                            <div className="min-w-0 space-y-1">
+                            <div className="min-w-0 space-y-1 sm:flex-1">
                               <div className="flex flex-wrap items-center gap-2">
                                 <Link
                                   href={`/cabinet/${encodedId}`}
@@ -774,23 +789,23 @@ export default function CabinetsPage() {
                                 </p>
                               )}
                             </div>
-                            <div className="flex flex-col gap-2 text-sm sm:w-auto sm:flex-row sm:flex-wrap">
+                            <div className="flex flex-col gap-2 text-sm sm:flex-none sm:flex-row sm:flex-wrap sm:justify-end">
                               <button
                                 type="button"
                                 onClick={() => toggleFavorite(row)}
-                                className={`${buttonClass({ variant: "secondary" })} w-full sm:w-auto`}
+                                className={`${buttonClass({ variant: "secondary" })} w-full whitespace-nowrap sm:w-auto`}
                               >
                                 {row.isFavorite ? "取消收藏" : "加入收藏"}
                               </button>
                               <Link
                                 href={`/cabinet/${encodedId}`}
-                                className={`${buttonClass({ variant: "secondary" })} w-full sm:w-auto`}
+                                className={`${buttonClass({ variant: "secondary" })} w-full whitespace-nowrap sm:w-auto`}
                               >
                                 查看物件
                               </Link>
                               <Link
                                 href={`/cabinet/${encodedId}/edit`}
-                                className={`${buttonClass({ variant: "secondary" })} w-full sm:w-auto`}
+                                className={`${buttonClass({ variant: "secondary" })} w-full whitespace-nowrap sm:w-auto`}
                               >
                                 編輯櫃子
                               </Link>
@@ -864,19 +879,19 @@ export default function CabinetsPage() {
                                   <button
                                     type="button"
                                     onClick={() => toggleFavorite(row)}
-                                    className={`${buttonClass({ variant: "secondary" })} w-full sm:w-auto`}
+                                    className={`${buttonClass({ variant: "secondary" })} w-full whitespace-nowrap sm:w-auto`}
                                   >
                                     {row.isFavorite ? "取消收藏" : "加入收藏"}
                                   </button>
                                   <Link
                                     href={`/cabinet/${encodedId}`}
-                                    className={`${buttonClass({ variant: "secondary" })} w-full sm:w-auto`}
+                                    className={`${buttonClass({ variant: "secondary" })} w-full whitespace-nowrap sm:w-auto`}
                                   >
                                     查看物件
                                   </Link>
                                   <Link
                                     href={`/cabinet/${encodedId}/edit`}
-                                    className={`${buttonClass({ variant: "secondary" })} w-full sm:w-auto`}
+                                    className={`${buttonClass({ variant: "secondary" })} w-full whitespace-nowrap sm:w-auto`}
                                   >
                                     編輯櫃子
                                   </Link>

--- a/src/app/cabinets/page.tsx
+++ b/src/app/cabinets/page.tsx
@@ -248,6 +248,13 @@ export default function CabinetsPage() {
   }, [totalPages]);
 
   useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }, [currentPageSafe]);
+
+  useEffect(() => {
     setReorderPage((prev) => Math.min(prev, reorderTotalPages));
   }, [reorderTotalPages]);
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -232,6 +232,10 @@ body {
   outline-offset: 2px;
 }
 
+:root[data-theme="dark"] .notes-list-item:hover {
+  background-color: rgba(148, 163, 184, 0.26) !important;
+}
+
 .progress-button {
   display: inline-flex;
   align-items: center;

--- a/src/app/notes/[id]/edit/page.tsx
+++ b/src/app/notes/[id]/edit/page.tsx
@@ -29,6 +29,7 @@ export default function EditNotePage({ params }: PageProps) {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [content, setContent] = useState("");
+  const [isFavorite, setIsFavorite] = useState(false);
   const [feedback, setFeedback] = useState<Feedback | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -70,6 +71,7 @@ export default function EditNotePage({ params }: PageProps) {
         if (!noteId) {
           setFeedback({ type: "error", message: "找不到對應的筆記" });
           setNotFound(true);
+          setIsFavorite(false);
           setLoading(false);
           return;
         }
@@ -81,6 +83,7 @@ export default function EditNotePage({ params }: PageProps) {
           setTitle("");
           setDescription("");
           setContent("");
+          setIsFavorite(false);
           setLoading(false);
           return;
         }
@@ -91,12 +94,14 @@ export default function EditNotePage({ params }: PageProps) {
           setTitle("");
           setDescription("");
           setContent("");
+          setIsFavorite(false);
           setLoading(false);
           return;
         }
-        setTitle(((data.title as string) ?? ""));
+        setTitle((data.title as string) ?? "");
         setDescription(typeof data.description === "string" ? data.description : "");
-        setContent(((data.content as string) ?? ""));
+        setContent((data.content as string) ?? "");
+        setIsFavorite(Boolean(data.isFavorite));
         setFeedback(null);
         setNotFound(false);
       } catch (err) {
@@ -106,6 +111,7 @@ export default function EditNotePage({ params }: PageProps) {
         setTitle("");
         setDescription("");
         setContent("");
+        setIsFavorite(false);
       } finally {
         setLoading(false);
       }
@@ -160,6 +166,7 @@ export default function EditNotePage({ params }: PageProps) {
         title: trimmedTitle,
         description: trimmedDescription ? trimmedDescription : null,
         content: trimmedContent,
+        isFavorite,
         updatedAt: serverTimestamp(),
       });
       setFeedback({ type: "success", message: "已更新筆記" });
@@ -273,6 +280,15 @@ export default function EditNotePage({ params }: PageProps) {
               <span className="block text-right text-xs text-gray-400">
                 {description.trim().length}/{DESCRIPTION_LIMIT}
               </span>
+            </label>
+            <label className="flex items-center gap-2 text-sm text-gray-700">
+              <input
+                type="checkbox"
+                checked={isFavorite}
+                onChange={(event) => setIsFavorite(event.target.checked)}
+                className="h-4 w-4 rounded border-gray-300 text-amber-500 focus:ring-amber-400"
+              />
+              設為最愛
             </label>
             <label className="block space-y-2">
               <span className="text-sm font-medium text-gray-700">筆記內容</span>

--- a/src/app/notes/[id]/edit/page.tsx
+++ b/src/app/notes/[id]/edit/page.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { FormEvent, useEffect, useState } from "react";
+import { onAuthStateChanged, type User } from "firebase/auth";
+import { doc, getDoc, serverTimestamp, updateDoc } from "firebase/firestore";
+
+import { getFirebaseAuth, getFirebaseDb } from "@/lib/firebase";
+import { buttonClass } from "@/lib/ui";
+
+const TITLE_LIMIT = 100;
+const DESCRIPTION_LIMIT = 300;
+
+type Feedback = {
+  type: "error" | "success";
+  message: string;
+};
+
+type PageProps = {
+  params: { id: string };
+};
+
+export default function EditNotePage({ params }: PageProps) {
+  const router = useRouter();
+  const [user, setUser] = useState<User | null>(null);
+  const [authChecked, setAuthChecked] = useState(false);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [content, setContent] = useState("");
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    const auth = getFirebaseAuth();
+    if (!auth) {
+      setAuthChecked(true);
+      setFeedback({ type: "error", message: "Firebase 尚未設定" });
+      setLoading(false);
+      return undefined;
+    }
+    const unsub = onAuthStateChanged(auth, (current) => {
+      setUser(current);
+      setAuthChecked(true);
+    });
+    return () => unsub();
+  }, []);
+
+  useEffect(() => {
+    if (!authChecked) {
+      return;
+    }
+    if (!user) {
+      setLoading(false);
+      return;
+    }
+    const db = getFirebaseDb();
+    if (!db) {
+      setFeedback({ type: "error", message: "Firebase 尚未設定" });
+      setLoading(false);
+      return;
+    }
+    async function loadNote() {
+      setLoading(true);
+      setNotFound(false);
+      try {
+        const noteRef = doc(db, "note", params.id);
+        const snap = await getDoc(noteRef);
+        if (!snap.exists()) {
+          setFeedback({ type: "error", message: "找不到對應的筆記" });
+          setNotFound(true);
+          setTitle("");
+          setDescription("");
+          setContent("");
+          setLoading(false);
+          return;
+        }
+        const data = snap.data();
+        if (!data || data.uid !== user.uid) {
+          setFeedback({ type: "error", message: "無法存取此筆記" });
+          setNotFound(true);
+          setTitle("");
+          setDescription("");
+          setContent("");
+          setLoading(false);
+          return;
+        }
+        setTitle(((data.title as string) ?? ""));
+        setDescription(typeof data.description === "string" ? data.description : "");
+        setContent(((data.content as string) ?? ""));
+        setFeedback(null);
+        setNotFound(false);
+      } catch (err) {
+        console.error("載入筆記時發生錯誤", err);
+        setFeedback({ type: "error", message: "載入筆記時發生錯誤" });
+        setNotFound(true);
+        setTitle("");
+        setDescription("");
+        setContent("");
+      } finally {
+        setLoading(false);
+      }
+    }
+    loadNote();
+  }, [authChecked, params.id, user]);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (saving || notFound) {
+      return;
+    }
+    if (!user) {
+      setFeedback({ type: "error", message: "請先登入" });
+      return;
+    }
+    const trimmedTitle = title.trim();
+    const trimmedDescription = description.trim();
+    const trimmedContent = content.trim();
+    if (!trimmedTitle) {
+      setFeedback({ type: "error", message: "請填寫筆記標題" });
+      return;
+    }
+    if (trimmedTitle.length > TITLE_LIMIT) {
+      setFeedback({ type: "error", message: `標題長度不可超過 ${TITLE_LIMIT} 字` });
+      return;
+    }
+    if (trimmedDescription.length > DESCRIPTION_LIMIT) {
+      setFeedback({ type: "error", message: `備註長度不可超過 ${DESCRIPTION_LIMIT} 字` });
+      return;
+    }
+    if (!trimmedContent) {
+      setFeedback({ type: "error", message: "請填寫筆記內容" });
+      return;
+    }
+
+    const db = getFirebaseDb();
+    if (!db) {
+      setFeedback({ type: "error", message: "Firebase 尚未設定" });
+      return;
+    }
+
+    setSaving(true);
+    setFeedback(null);
+    try {
+      const noteRef = doc(db, "note", params.id);
+      await updateDoc(noteRef, {
+        title: trimmedTitle,
+        description: trimmedDescription ? trimmedDescription : null,
+        content: trimmedContent,
+        updatedAt: serverTimestamp(),
+      });
+      setFeedback({ type: "success", message: "已更新筆記" });
+      router.replace(`/notes/${params.id}`);
+    } catch (err) {
+      console.error("更新筆記時發生錯誤", err);
+      setFeedback({ type: "error", message: "更新筆記時發生錯誤" });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!authChecked) {
+    return (
+      <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+        <div className="mx-auto w-full max-w-2xl rounded-2xl border bg-white/70 p-6 text-base shadow-sm">
+          正在確認登入狀態…
+        </div>
+      </main>
+    );
+  }
+
+  if (!user) {
+    return (
+      <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+        <div className="mx-auto flex w-full max-w-2xl flex-col gap-4 rounded-2xl border bg-white/70 p-6 shadow-sm">
+          <h1 className="text-2xl font-semibold text-gray-900">編輯筆記</h1>
+          <p className="text-base text-gray-600">
+            未登入。請前往
+            <Link href="/login" className="ml-1 underline">
+              /login
+            </Link>
+            以管理筆記，或回到
+            <Link href="/" className="ml-1 underline">
+              首頁
+            </Link>
+            了解更多功能。
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  if (loading) {
+    return (
+      <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+        <div className="mx-auto w-full max-w-2xl rounded-2xl border bg-white/70 p-6 text-base shadow-sm">
+          正在載入筆記…
+        </div>
+      </main>
+    );
+  }
+
+  if (notFound) {
+    return (
+      <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+        <div className="mx-auto w-full max-w-2xl space-y-4 rounded-2xl border bg-white/70 p-6 text-base shadow-sm">
+          <header className="space-y-2">
+            <h1 className="text-2xl font-semibold text-gray-900">編輯筆記</h1>
+          </header>
+          <div className="break-anywhere rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {feedback?.message ?? "找不到筆記，無法進行編輯。"}
+          </div>
+          <Link href="/notes" className={buttonClass({ variant: "secondary" })}>
+            返回筆記本
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+      <div className="mx-auto w-full max-w-2xl space-y-6">
+        <header className="space-y-2">
+          <Link href={`/notes/${params.id}`} className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700">
+            ← 返回筆記詳情
+          </Link>
+          <h1 className="text-2xl font-semibold text-gray-900">編輯筆記</h1>
+          <p className="text-sm text-gray-500">調整筆記內容並保存最新版本。</p>
+        </header>
+        <section className="rounded-2xl border bg-white/70 p-6 shadow-sm">
+          <form className="space-y-6" onSubmit={handleSubmit}>
+            <label className="block space-y-2">
+              <span className="text-sm font-medium text-gray-700">筆記標題</span>
+              <input
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                placeholder="輸入筆記標題"
+                maxLength={TITLE_LIMIT}
+                required
+                className="h-12 w-full rounded-xl border px-4 text-base"
+                autoFocus
+              />
+              <span className="block text-right text-xs text-gray-400">
+                {title.trim().length}/{TITLE_LIMIT}
+              </span>
+            </label>
+            <label className="block space-y-2">
+              <span className="text-sm font-medium text-gray-700">筆記備註</span>
+              <textarea
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                placeholder="補充筆記相關備註（選填）"
+                maxLength={DESCRIPTION_LIMIT}
+                className="min-h-[100px] w-full resize-y rounded-xl border px-4 py-3 text-base"
+              />
+              <span className="block text-right text-xs text-gray-400">
+                {description.trim().length}/{DESCRIPTION_LIMIT}
+              </span>
+            </label>
+            <label className="block space-y-2">
+              <span className="text-sm font-medium text-gray-700">筆記內容</span>
+              <textarea
+                value={content}
+                onChange={(event) => setContent(event.target.value)}
+                placeholder="輸入筆記內容"
+                required
+                className="min-h-[220px] w-full resize-y rounded-xl border px-4 py-3 text-base"
+              />
+            </label>
+            {feedback ? (
+              <div
+                className={
+                  feedback.type === "error"
+                    ? "break-anywhere rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700"
+                    : "break-anywhere rounded-xl bg-emerald-50 px-4 py-3 text-sm text-emerald-700"
+                }
+              >
+                {feedback.message}
+              </div>
+            ) : null}
+            <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+              <Link
+                href={`/notes/${params.id}`}
+                className={`${buttonClass({ variant: "secondary" })} w-full sm:w-auto`}
+              >
+                取消
+              </Link>
+              <button
+                type="submit"
+                disabled={saving}
+                className={`${buttonClass({ variant: "primary" })} w-full sm:w-auto`}
+              >
+                {saving ? "儲存中…" : "儲存"}
+              </button>
+            </div>
+          </form>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/notes/[id]/page.tsx
+++ b/src/app/notes/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { use, useEffect, useMemo, useState } from "react";
 import { onAuthStateChanged, type User } from "firebase/auth";
 import { deleteDoc, doc, onSnapshot, Timestamp } from "firebase/firestore";
 
@@ -10,7 +10,7 @@ import { getFirebaseAuth, getFirebaseDb } from "@/lib/firebase";
 import { buttonClass } from "@/lib/ui";
 
 type PageProps = {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 };
 
 type Note = {
@@ -47,6 +47,7 @@ function formatDateTime(ms: number): string {
 }
 
 export default function NoteDetailPage({ params }: PageProps) {
+  const { id: noteId } = use(params);
   const router = useRouter();
   const [user, setUser] = useState<User | null>(null);
   const [authChecked, setAuthChecked] = useState(false);
@@ -86,7 +87,10 @@ export default function NoteDetailPage({ params }: PageProps) {
       setLoading(false);
       return;
     }
-    const noteRef = doc(db, "note", params.id);
+    if (!noteId) {
+      return;
+    }
+    const noteRef = doc(db, "note", noteId);
     const unsub = onSnapshot(
       noteRef,
       (snap) => {
@@ -127,7 +131,7 @@ export default function NoteDetailPage({ params }: PageProps) {
       }
     );
     return () => unsub();
-  }, [authChecked, params.id, user]);
+  }, [authChecked, noteId, user]);
 
   const metaInfo = useMemo(() => {
     if (!note) {

--- a/src/app/notes/[id]/page.tsx
+++ b/src/app/notes/[id]/page.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+import { onAuthStateChanged, type User } from "firebase/auth";
+import { deleteDoc, doc, onSnapshot, Timestamp } from "firebase/firestore";
+
+import { getFirebaseAuth, getFirebaseDb } from "@/lib/firebase";
+import { buttonClass } from "@/lib/ui";
+
+type PageProps = {
+  params: { id: string };
+};
+
+type Note = {
+  id: string;
+  title: string;
+  description: string | null;
+  content: string;
+  createdMs: number;
+  updatedMs: number;
+};
+
+type Feedback = {
+  type: "error" | "success";
+  message: string;
+};
+
+const dateFormatter = new Intl.DateTimeFormat("zh-TW", {
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
+function formatDateTime(ms: number): string {
+  if (!ms) {
+    return "—";
+  }
+  try {
+    return dateFormatter.format(new Date(ms));
+  } catch {
+    return "—";
+  }
+}
+
+export default function NoteDetailPage({ params }: PageProps) {
+  const router = useRouter();
+  const [user, setUser] = useState<User | null>(null);
+  const [authChecked, setAuthChecked] = useState(false);
+  const [note, setNote] = useState<Note | null>(null);
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [deleting, setDeleting] = useState(false);
+
+  useEffect(() => {
+    const auth = getFirebaseAuth();
+    if (!auth) {
+      setAuthChecked(true);
+      setFeedback({ type: "error", message: "Firebase 尚未設定" });
+      setLoading(false);
+      return undefined;
+    }
+
+    const unsub = onAuthStateChanged(auth, (current) => {
+      setUser(current);
+      setAuthChecked(true);
+    });
+    return () => unsub();
+  }, []);
+
+  useEffect(() => {
+    if (!authChecked) {
+      return;
+    }
+    if (!user) {
+      setNote(null);
+      setLoading(false);
+      return;
+    }
+    const db = getFirebaseDb();
+    if (!db) {
+      setFeedback({ type: "error", message: "Firebase 尚未設定" });
+      setLoading(false);
+      return;
+    }
+    const noteRef = doc(db, "note", params.id);
+    const unsub = onSnapshot(
+      noteRef,
+      (snap) => {
+        if (!snap.exists()) {
+          setNote(null);
+          setFeedback({ type: "error", message: "找不到對應的筆記" });
+          setLoading(false);
+          return;
+        }
+        const data = snap.data();
+        if (!data || data.uid !== user.uid) {
+          setNote(null);
+          setFeedback({ type: "error", message: "無法存取此筆記" });
+          setLoading(false);
+          return;
+        }
+        const createdAt = data.createdAt;
+        const updatedAt = data.updatedAt;
+        const createdMs = createdAt instanceof Timestamp ? createdAt.toMillis() : 0;
+        const updatedMs = updatedAt instanceof Timestamp ? updatedAt.toMillis() : createdMs;
+        setNote({
+          id: snap.id,
+          title: (data.title as string) || "",
+          description:
+            typeof data.description === "string" && data.description.trim().length > 0
+              ? data.description.trim()
+              : null,
+          content: (data.content as string) || "",
+          createdMs,
+          updatedMs,
+        });
+        setFeedback(null);
+        setLoading(false);
+      },
+      () => {
+        setFeedback({ type: "error", message: "載入筆記時發生錯誤" });
+        setLoading(false);
+      }
+    );
+    return () => unsub();
+  }, [authChecked, params.id, user]);
+
+  const metaInfo = useMemo(() => {
+    if (!note) {
+      return null;
+    }
+    return (
+      <dl className="grid gap-4 rounded-2xl border border-gray-200 bg-white/60 p-4 text-sm text-gray-600 sm:grid-cols-2">
+        <div className="space-y-1">
+          <dt className="font-medium text-gray-700">建立時間</dt>
+          <dd>{formatDateTime(note.createdMs)}</dd>
+        </div>
+        <div className="space-y-1">
+          <dt className="font-medium text-gray-700">更新時間</dt>
+          <dd>{formatDateTime(note.updatedMs)}</dd>
+        </div>
+      </dl>
+    );
+  }, [note]);
+
+  async function handleDelete() {
+    if (!note || deleting) {
+      return;
+    }
+    const confirmed = typeof window !== "undefined" ? window.confirm("確定要刪除這筆筆記嗎？") : false;
+    if (!confirmed) {
+      return;
+    }
+    const db = getFirebaseDb();
+    if (!db) {
+      setFeedback({ type: "error", message: "Firebase 尚未設定" });
+      return;
+    }
+    setDeleting(true);
+    setFeedback(null);
+    try {
+      await deleteDoc(doc(db, "note", note.id));
+      router.replace("/notes");
+    } catch (err) {
+      console.error("刪除筆記時發生錯誤", err);
+      setFeedback({ type: "error", message: "刪除筆記時發生錯誤" });
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  if (!authChecked) {
+    return (
+      <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+        <div className="mx-auto w-full max-w-3xl rounded-2xl border bg-white/70 p-6 text-base shadow-sm">
+          正在確認登入狀態…
+        </div>
+      </main>
+    );
+  }
+
+  if (!user) {
+    return (
+      <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 rounded-2xl border bg-white/70 p-6 shadow-sm">
+          <h1 className="text-2xl font-semibold text-gray-900">筆記詳情</h1>
+          <p className="text-base text-gray-600">
+            未登入。請前往
+            <Link href="/login" className="ml-1 underline">
+              /login
+            </Link>
+            以管理筆記，或回到
+            <Link href="/" className="ml-1 underline">
+              首頁
+            </Link>
+            了解更多功能。
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  if (loading) {
+    return (
+      <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+        <div className="mx-auto w-full max-w-3xl rounded-2xl border bg-white/70 p-6 text-base shadow-sm">
+          正在載入筆記…
+        </div>
+      </main>
+    );
+  }
+
+  if (!note) {
+    return (
+      <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+        <div className="mx-auto w-full max-w-3xl space-y-4 rounded-2xl border bg-white/70 p-6 text-base shadow-sm">
+          <header className="space-y-2">
+            <h1 className="text-2xl font-semibold text-gray-900">筆記詳情</h1>
+          </header>
+          {feedback ? (
+            <div className="break-anywhere rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+              {feedback.message}
+            </div>
+          ) : (
+            <p className="text-sm text-gray-600">找不到筆記，可能已被刪除。</p>
+          )}
+          <Link href="/notes" className={buttonClass({ variant: "secondary" })}>
+            返回筆記本
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-6">
+        <header className="space-y-3">
+          <Link href="/notes" className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700">
+            ← 返回筆記本
+          </Link>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="space-y-2">
+              <h1 className="text-3xl font-semibold text-gray-900">{note.title || "(未命名筆記)"}</h1>
+              {note.description ? (
+                <p className="whitespace-pre-line text-sm text-gray-600">{note.description}</p>
+              ) : null}
+            </div>
+            <div className="flex gap-3">
+              <Link
+                href={`/notes/${note.id}/edit`}
+                className={buttonClass({ variant: "secondary" })}
+              >
+                編輯筆記
+              </Link>
+              <button
+                type="button"
+                onClick={handleDelete}
+                disabled={deleting}
+                className={buttonClass({ variant: "outlineDanger" })}
+              >
+                {deleting ? "刪除中…" : "刪除筆記"}
+              </button>
+            </div>
+          </div>
+        </header>
+        {metaInfo}
+        <section className="rounded-2xl border border-gray-200 bg-white/70 p-6 shadow-sm">
+          <h2 className="mb-4 text-lg font-semibold text-gray-900">筆記內容</h2>
+          <p className="whitespace-pre-wrap break-words text-base leading-relaxed text-gray-700">
+            {note.content}
+          </p>
+        </section>
+        {feedback && feedback.type === "error" ? (
+          <div className="break-anywhere rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {feedback.message}
+          </div>
+        ) : null}
+      </div>
+    </main>
+  );
+}

--- a/src/app/notes/new/page.tsx
+++ b/src/app/notes/new/page.tsx
@@ -24,6 +24,7 @@ export default function NewNotePage() {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [content, setContent] = useState("");
+  const [isFavorite, setIsFavorite] = useState(false);
   const [feedback, setFeedback] = useState<Feedback | null>(null);
   const [saving, setSaving] = useState(false);
 
@@ -85,6 +86,7 @@ export default function NewNotePage() {
         title: trimmedTitle,
         description: trimmedDescription ? trimmedDescription : null,
         content: trimmedContent,
+        isFavorite,
         createdAt: serverTimestamp(),
         updatedAt: serverTimestamp(),
       });
@@ -92,6 +94,7 @@ export default function NewNotePage() {
       setTitle("");
       setDescription("");
       setContent("");
+      setIsFavorite(false);
       router.replace("/notes");
     } catch (err) {
       console.error("新增筆記時發生錯誤", err);
@@ -168,6 +171,15 @@ export default function NewNotePage() {
               <span className="block text-right text-xs text-gray-400">
                 {description.trim().length}/{DESCRIPTION_LIMIT}
               </span>
+            </label>
+            <label className="flex items-center gap-2 text-sm text-gray-700">
+              <input
+                type="checkbox"
+                checked={isFavorite}
+                onChange={(event) => setIsFavorite(event.target.checked)}
+                className="h-4 w-4 rounded border-gray-300 text-amber-500 focus:ring-amber-400"
+              />
+              設為最愛
             </label>
             <label className="block space-y-2">
               <span className="text-sm font-medium text-gray-700">筆記內容</span>

--- a/src/app/notes/new/page.tsx
+++ b/src/app/notes/new/page.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { FormEvent, useEffect, useState } from "react";
+import { onAuthStateChanged, type User } from "firebase/auth";
+import { addDoc, collection, serverTimestamp } from "firebase/firestore";
+
+import { getFirebaseAuth, getFirebaseDb } from "@/lib/firebase";
+import { buttonClass } from "@/lib/ui";
+
+const TITLE_LIMIT = 100;
+const DESCRIPTION_LIMIT = 300;
+
+type Feedback = {
+  type: "error" | "success";
+  message: string;
+};
+
+export default function NewNotePage() {
+  const router = useRouter();
+  const [user, setUser] = useState<User | null>(null);
+  const [authChecked, setAuthChecked] = useState(false);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [content, setContent] = useState("");
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    const auth = getFirebaseAuth();
+    if (!auth) {
+      setAuthChecked(true);
+      setFeedback({ type: "error", message: "Firebase 尚未設定" });
+      return undefined;
+    }
+    const unsub = onAuthStateChanged(auth, (current) => {
+      setUser(current);
+      setAuthChecked(true);
+    });
+    return () => unsub();
+  }, []);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (saving) {
+      return;
+    }
+    if (!user) {
+      setFeedback({ type: "error", message: "請先登入" });
+      return;
+    }
+    const trimmedTitle = title.trim();
+    const trimmedDescription = description.trim();
+    const trimmedContent = content.trim();
+    if (!trimmedTitle) {
+      setFeedback({ type: "error", message: "請填寫筆記標題" });
+      return;
+    }
+    if (trimmedTitle.length > TITLE_LIMIT) {
+      setFeedback({ type: "error", message: `標題長度不可超過 ${TITLE_LIMIT} 字` });
+      return;
+    }
+    if (trimmedDescription.length > DESCRIPTION_LIMIT) {
+      setFeedback({ type: "error", message: `備註長度不可超過 ${DESCRIPTION_LIMIT} 字` });
+      return;
+    }
+    if (!trimmedContent) {
+      setFeedback({ type: "error", message: "請填寫筆記內容" });
+      return;
+    }
+
+    const db = getFirebaseDb();
+    if (!db) {
+      setFeedback({ type: "error", message: "Firebase 尚未設定" });
+      return;
+    }
+
+    setSaving(true);
+    setFeedback(null);
+
+    try {
+      await addDoc(collection(db, "note"), {
+        uid: user.uid,
+        title: trimmedTitle,
+        description: trimmedDescription ? trimmedDescription : null,
+        content: trimmedContent,
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+      });
+      setFeedback({ type: "success", message: "已新增筆記" });
+      setTitle("");
+      setDescription("");
+      setContent("");
+      router.replace("/notes");
+    } catch (err) {
+      console.error("新增筆記時發生錯誤", err);
+      setFeedback({ type: "error", message: "新增筆記時發生錯誤" });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!authChecked) {
+    return (
+      <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+        <div className="mx-auto w-full max-w-2xl rounded-2xl border bg-white/70 p-6 text-base shadow-sm">
+          正在確認登入狀態…
+        </div>
+      </main>
+    );
+  }
+
+  if (!user) {
+    return (
+      <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+        <div className="mx-auto flex w-full max-w-2xl flex-col gap-4 rounded-2xl border bg-white/70 p-6 shadow-sm">
+          <h1 className="text-2xl font-semibold text-gray-900">新增筆記</h1>
+          <p className="text-base text-gray-600">
+            未登入。請前往
+            <Link href="/login" className="ml-1 underline">
+              /login
+            </Link>
+            以管理筆記，或回到
+            <Link href="/" className="ml-1 underline">
+              首頁
+            </Link>
+            了解更多功能。
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+      <div className="mx-auto w-full max-w-2xl space-y-6">
+        <header className="space-y-2">
+          <h1 className="text-2xl font-semibold text-gray-900">新增筆記</h1>
+          <p className="text-sm text-gray-500">建立新的筆記並記錄重要資訊。</p>
+        </header>
+        <section className="rounded-2xl border bg-white/70 p-6 shadow-sm">
+          <form className="space-y-6" onSubmit={handleSubmit}>
+            <label className="block space-y-2">
+              <span className="text-sm font-medium text-gray-700">筆記標題</span>
+              <input
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                placeholder="輸入筆記標題"
+                maxLength={TITLE_LIMIT}
+                required
+                className="h-12 w-full rounded-xl border px-4 text-base"
+                autoFocus
+              />
+              <span className="block text-right text-xs text-gray-400">
+                {title.trim().length}/{TITLE_LIMIT}
+              </span>
+            </label>
+            <label className="block space-y-2">
+              <span className="text-sm font-medium text-gray-700">筆記備註</span>
+              <textarea
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                placeholder="補充筆記相關備註（選填）"
+                maxLength={DESCRIPTION_LIMIT}
+                className="min-h-[100px] w-full resize-y rounded-xl border px-4 py-3 text-base"
+              />
+              <span className="block text-right text-xs text-gray-400">
+                {description.trim().length}/{DESCRIPTION_LIMIT}
+              </span>
+            </label>
+            <label className="block space-y-2">
+              <span className="text-sm font-medium text-gray-700">筆記內容</span>
+              <textarea
+                value={content}
+                onChange={(event) => setContent(event.target.value)}
+                placeholder="輸入筆記內容"
+                required
+                className="min-h-[220px] w-full resize-y rounded-xl border px-4 py-3 text-base"
+              />
+            </label>
+            {feedback ? (
+              <div
+                className={
+                  feedback.type === "error"
+                    ? "break-anywhere rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700"
+                    : "break-anywhere rounded-xl bg-emerald-50 px-4 py-3 text-sm text-emerald-700"
+                }
+              >
+                {feedback.message}
+              </div>
+            ) : null}
+            <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+              <Link href="/notes" className={`${buttonClass({ variant: "secondary" })} w-full sm:w-auto`}>
+                取消
+              </Link>
+              <button
+                type="submit"
+                disabled={saving}
+                className={`${buttonClass({ variant: "primary" })} w-full sm:w-auto`}
+              >
+                {saving ? "儲存中…" : "儲存"}
+              </button>
+            </div>
+          </form>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -66,6 +66,13 @@ export default function NotesPage() {
     })} whitespace-nowrap px-3`;
 
   useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }, [currentPage]);
+
+  useEffect(() => {
     const auth = getFirebaseAuth();
     if (!auth) {
       setAuthChecked(true);
@@ -199,7 +206,7 @@ export default function NotesPage() {
           <li key={note.id}>
             <Link
               href={`/notes/${note.id}`}
-              className="flex flex-col gap-2 px-6 py-5 transition hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
+              className="notes-list-item flex flex-col gap-2 px-6 py-5 transition hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
             >
               <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
                 <div className="flex min-w-0 items-start gap-2">

--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { onAuthStateChanged, type User } from "firebase/auth";
+import { collection, onSnapshot, query, Timestamp, where } from "firebase/firestore";
+
+import { getFirebaseAuth, getFirebaseDb } from "@/lib/firebase";
+import { buttonClass } from "@/lib/ui";
+
+type Note = {
+  id: string;
+  title: string;
+  summary: string | null;
+  createdMs: number;
+  updatedMs: number;
+};
+
+type Feedback = {
+  type: "error" | "success";
+  message: string;
+};
+
+const dateFormatter = new Intl.DateTimeFormat("zh-TW", {
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
+function formatDateTime(ms: number): string {
+  if (!ms) {
+    return "—";
+  }
+  try {
+    return dateFormatter.format(new Date(ms));
+  } catch {
+    return "—";
+  }
+}
+
+export default function NotesPage() {
+  const [user, setUser] = useState<User | null>(null);
+  const [authChecked, setAuthChecked] = useState(false);
+  const [notes, setNotes] = useState<Note[]>([]);
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
+
+  useEffect(() => {
+    const auth = getFirebaseAuth();
+    if (!auth) {
+      setAuthChecked(true);
+      setFeedback({ type: "error", message: "Firebase 尚未設定" });
+      return undefined;
+    }
+
+    const unsub = onAuthStateChanged(auth, (current) => {
+      setUser(current);
+      setAuthChecked(true);
+    });
+    return () => unsub();
+  }, []);
+
+  useEffect(() => {
+    if (!user) {
+      setNotes([]);
+      return;
+    }
+    const db = getFirebaseDb();
+    if (!db) {
+      setFeedback({ type: "error", message: "Firebase 尚未設定" });
+      return;
+    }
+
+    const q = query(collection(db, "note"), where("uid", "==", user.uid));
+    const unsub = onSnapshot(
+      q,
+      (snapshot) => {
+        const rows: Note[] = snapshot.docs
+          .map((docSnap) => {
+            const data = docSnap.data();
+            const createdAt = data?.createdAt;
+            const updatedAt = data?.updatedAt;
+            const createdMs = createdAt instanceof Timestamp ? createdAt.toMillis() : 0;
+            const updatedMs = updatedAt instanceof Timestamp ? updatedAt.toMillis() : createdMs;
+            const summary =
+              typeof data?.description === "string" && data.description.trim().length > 0
+                ? data.description.trim()
+                : null;
+            return {
+              id: docSnap.id,
+              title: (data?.title as string) || "",
+              summary,
+              createdMs,
+              updatedMs,
+            } satisfies Note;
+          })
+          .sort((a, b) => b.updatedMs - a.updatedMs);
+        setNotes(rows);
+        setFeedback(null);
+      },
+      () => {
+        setFeedback({ type: "error", message: "載入筆記時發生錯誤" });
+      }
+    );
+    return () => unsub();
+  }, [user]);
+
+  const hasNotes = notes.length > 0;
+
+  const content = useMemo(() => {
+    if (!hasNotes) {
+      return (
+        <div className="rounded-2xl border border-dashed border-gray-200 bg-white/60 p-10 text-center text-gray-500">
+          尚未建立任何筆記。
+        </div>
+      );
+    }
+
+    return (
+      <ul className="divide-y rounded-2xl border border-gray-200 bg-white/70 shadow-sm">
+        {notes.map((note) => (
+          <li key={note.id}>
+            <Link
+              href={`/notes/${note.id}`}
+              className="flex flex-col gap-2 px-6 py-5 transition hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
+            >
+              <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                <h2 className="text-lg font-semibold text-gray-900">{note.title || "(未命名筆記)"}</h2>
+                <dl className="flex flex-wrap gap-x-6 gap-y-1 text-xs text-gray-500">
+                  <div className="flex gap-1">
+                    <dt className="font-medium">建立：</dt>
+                    <dd>{formatDateTime(note.createdMs)}</dd>
+                  </div>
+                  <div className="flex gap-1">
+                    <dt className="font-medium">更新：</dt>
+                    <dd>{formatDateTime(note.updatedMs)}</dd>
+                  </div>
+                </dl>
+              </div>
+              {note.summary ? (
+                <p className="line-clamp-2 text-sm text-gray-600">{note.summary}</p>
+              ) : null}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    );
+  }, [hasNotes, notes]);
+
+  if (!authChecked) {
+    return (
+      <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+        <div className="mx-auto w-full max-w-4xl rounded-2xl border bg-white/70 p-6 text-base shadow-sm">
+          正在確認登入狀態…
+        </div>
+      </main>
+    );
+  }
+
+  if (!user) {
+    return (
+      <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+        <div className="mx-auto flex w-full max-w-4xl flex-col gap-4 rounded-2xl border bg-white/70 p-6 shadow-sm">
+          <h1 className="text-2xl font-semibold text-gray-900">筆記本</h1>
+          <p className="text-base text-gray-600">
+            未登入。請前往
+            <Link href="/login" className="ml-1 underline">
+              /login
+            </Link>
+            以管理筆記，或回到
+            <Link href="/" className="ml-1 underline">
+              首頁
+            </Link>
+            了解更多功能。
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-6">
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold text-gray-900">筆記本</h1>
+            <p className="text-sm text-gray-500">管理與檢視所有筆記紀錄。</p>
+          </div>
+          <Link href="/notes/new" className={buttonClass({ variant: "primary" })}>
+            新增筆記
+          </Link>
+        </header>
+        {feedback && feedback.type === "error" ? (
+          <div className="break-anywhere rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {feedback.message}
+          </div>
+        ) : null}
+        {content}
+      </div>
+    </main>
+  );
+}

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -46,6 +46,7 @@ export default function AppHeader() {
       { href: "/cabinets", label: "我的櫃子" },
       { href: "/item/new", label: "新增物件" },
       { href: "/item/quick-add", label: "快速新增物件" },
+      { href: "/notes", label: "筆記本" },
     ],
     []
   );


### PR DESCRIPTION
## Summary
- add a dedicated "/cabinets/new" page with a form for creating cabinets and link it from the cabinets header
- extend the cabinets listing with favorite toggles, search/filter controls, pagination, and multiple display modes
- update cabinet data handling to track favorite and updated timestamps for new filtering and sorting options

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3511c8a988320b8783e6325d2a31d