### PR TITLE
feat: connect notes with items and enhance note tools

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -7,20 +7,47 @@ service cloud.firestore {
       return field is string && field.size() >= 1 && field.size() <= maxLen;
     }
 
+    function isString(field, maxLen) {
+      return field is string && field.size() <= maxLen;
+    }
+
     function isOptionalString(field, maxLen) {
-      return field == null || (field is string && field.size() <= maxLen);
+      return field == null || isString(field, maxLen);
     }
 
     function isTimestamp(value) {
       return value is timestamp;
     }
 
+    function hasNoteContent(data) {
+      return ("content" in data && isString(data.content, 60000))
+        && (
+          data.content.size() > 0 ||
+          (("contentMarkdown" in data) && isString(data.contentMarkdown, 60000) && data.contentMarkdown.size() > 0)
+        );
+    }
+
     function isValidNoteData(data) {
       return data.uid is string
         && isNonEmptyString(data.title, 100)
-        && isNonEmptyString(data.content, 60000)
+        && ("content" in data && isString(data.content, 60000))
+        && (!("contentMarkdown" in data) || isString(data.contentMarkdown, 60000))
+        && hasNoteContent(data)
         && ("description" in data ? isOptionalString(data.description, 300) : true)
         && ("isFavorite" in data ? data.isFavorite is bool : true)
+        && ("category" in data ? (data.category == null || data.category in ["general", "progress", "insight", "reference"]) : true)
+        && ("tags" in data ? data.tags is list
+             && data.tags.size() <= 20
+             && data.tags.size() == data.tags.where(tag => tag is string && tag.size() >= 1 && tag.size() <= 50).size()
+             : true)
+        && ("linkedCabinetIds" in data ? data.linkedCabinetIds is list
+             && data.linkedCabinetIds.size() <= 50
+             && data.linkedCabinetIds.size() == data.linkedCabinetIds.where(cabinetId => cabinetId is string && cabinetId.size() >= 1 && cabinetId.size() <= 100).size()
+             : true)
+        && ("linkedItemIds" in data ? data.linkedItemIds is list
+             && data.linkedItemIds.size() <= 50
+             && data.linkedItemIds.size() == data.linkedItemIds.where(itemId => itemId is string && itemId.size() >= 1 && itemId.size() <= 100).size()
+             : true)
         && isTimestamp(data.createdAt)
         && isTimestamp(data.updatedAt);
     }

--- a/firestore.rules
+++ b/firestore.rules
@@ -15,10 +15,13 @@ service cloud.firestore {
       return field == null || isString(field, maxLen);
     }
 
-    function isStringList(list, maxItems, minLen, maxLen) {
+    function isStringList(list, minLen, maxLen) {
       return list is list
-        && list.size() <= maxItems
         && list.size() == list.where(item, item is string && item.size() >= minLen && item.size() <= maxLen).size();
+    }
+
+    function isBoundedStringList(list, maxItems, minLen, maxLen) {
+      return isStringList(list, minLen, maxLen) && list.size() <= maxItems;
     }
 
     function isTimestamp(value) {
@@ -32,20 +35,31 @@ service cloud.firestore {
       );
     }
 
-    function isValidNoteData(data) {
+    function hasExistingNoteContent() {
+      return resource != null && resource.data != null && hasNoteContent(resource.data);
+    }
+
+    function isValidNoteBase(data) {
       return data.uid is string
         && isNonEmptyString(data.title, 100)
         && (!("content" in data) || isString(data.content, 60000))
         && (!("contentMarkdown" in data) || isString(data.contentMarkdown, 60000))
-        && hasNoteContent(data)
         && ("description" in data ? isOptionalString(data.description, 300) : true)
         && ("isFavorite" in data ? data.isFavorite is bool : true)
         && ("category" in data ? (data.category == null || data.category in ["general", "progress", "insight", "reference"]) : true)
-        && (!("tags" in data) || isStringList(data.tags, 20, 1, 50))
-        && (!("linkedCabinetIds" in data) || isStringList(data.linkedCabinetIds, 50, 1, 100))
-        && (!("linkedItemIds" in data) || isStringList(data.linkedItemIds, 50, 1, 100))
+        && (!("tags" in data) || isStringList(data.tags, 1, 50))
+        && (!("linkedCabinetIds" in data) || isBoundedStringList(data.linkedCabinetIds, 50, 1, 100))
+        && (!("linkedItemIds" in data) || isBoundedStringList(data.linkedItemIds, 50, 1, 100))
         && isTimestamp(data.createdAt)
         && isTimestamp(data.updatedAt);
+    }
+
+    function isValidNoteCreate(data) {
+      return isValidNoteBase(data) && hasNoteContent(data);
+    }
+
+    function isValidNoteUpdate(data) {
+      return isValidNoteBase(data) && (hasNoteContent(data) || hasExistingNoteContent());
     }
 
     // 櫃子
@@ -91,11 +105,11 @@ service cloud.firestore {
       allow read: if authed() && resource.data.uid == request.auth.uid;
       allow create: if authed()
                     && request.resource.data.uid == request.auth.uid
-                    && isValidNoteData(request.resource.data);
+                    && isValidNoteCreate(request.resource.data);
       allow update: if authed()
                     && resource.data.uid == request.auth.uid
                     && request.resource.data.uid == request.auth.uid
-                    && isValidNoteData(request.resource.data)
+                    && isValidNoteUpdate(request.resource.data)
                     && request.resource.data.createdAt == resource.data.createdAt;
       allow delete: if authed() && resource.data.uid == request.auth.uid;
     }

--- a/firestore.rules
+++ b/firestore.rules
@@ -15,39 +15,35 @@ service cloud.firestore {
       return field == null || isString(field, maxLen);
     }
 
+    function isStringList(list, maxItems, minLen, maxLen) {
+      return list is list
+        && list.size() <= maxItems
+        && list.size() == list.where(item, item is string && item.size() >= minLen && item.size() <= maxLen).size();
+    }
+
     function isTimestamp(value) {
       return value is timestamp;
     }
 
     function hasNoteContent(data) {
-      return ("content" in data && isString(data.content, 60000))
-        && (
-          data.content.size() > 0 ||
-          (("contentMarkdown" in data) && isString(data.contentMarkdown, 60000) && data.contentMarkdown.size() > 0)
-        );
+      return (
+          ("content" in data && isString(data.content, 60000) && data.content.size() > 0)
+        || ("contentMarkdown" in data && isString(data.contentMarkdown, 60000) && data.contentMarkdown.size() > 0)
+      );
     }
 
     function isValidNoteData(data) {
       return data.uid is string
         && isNonEmptyString(data.title, 100)
-        && ("content" in data && isString(data.content, 60000))
+        && (!("content" in data) || isString(data.content, 60000))
         && (!("contentMarkdown" in data) || isString(data.contentMarkdown, 60000))
         && hasNoteContent(data)
         && ("description" in data ? isOptionalString(data.description, 300) : true)
         && ("isFavorite" in data ? data.isFavorite is bool : true)
         && ("category" in data ? (data.category == null || data.category in ["general", "progress", "insight", "reference"]) : true)
-        && ("tags" in data ? data.tags is list
-             && data.tags.size() <= 20
-             && data.tags.size() == data.tags.where(tag => tag is string && tag.size() >= 1 && tag.size() <= 50).size()
-             : true)
-        && ("linkedCabinetIds" in data ? data.linkedCabinetIds is list
-             && data.linkedCabinetIds.size() <= 50
-             && data.linkedCabinetIds.size() == data.linkedCabinetIds.where(cabinetId => cabinetId is string && cabinetId.size() >= 1 && cabinetId.size() <= 100).size()
-             : true)
-        && ("linkedItemIds" in data ? data.linkedItemIds is list
-             && data.linkedItemIds.size() <= 50
-             && data.linkedItemIds.size() == data.linkedItemIds.where(itemId => itemId is string && itemId.size() >= 1 && itemId.size() <= 100).size()
-             : true)
+        && (!("tags" in data) || isStringList(data.tags, 20, 1, 50))
+        && (!("linkedCabinetIds" in data) || isStringList(data.linkedCabinetIds, 50, 1, 100))
+        && (!("linkedItemIds" in data) || isStringList(data.linkedItemIds, 50, 1, 100))
         && isTimestamp(data.createdAt)
         && isTimestamp(data.updatedAt);
     }

--- a/firestore.rules
+++ b/firestore.rules
@@ -28,7 +28,7 @@ service cloud.firestore {
     }
 
     function isTimestamp(value) {
-      return value is timestamp;
+      return value is timestamp || value == request.time;
     }
 
     function hasNoteContent(data) {
@@ -39,7 +39,13 @@ service cloud.firestore {
     }
 
     function hasExistingNoteContent() {
-      return resource != null && resource.data != null && hasNoteContent(resource.data);
+      return resource != null
+        && resource.data != null
+        && (
+          hasNoteContent(resource.data)
+          || (("content" in resource.data) && resource.data.content is string)
+          || (("contentMarkdown" in resource.data) && resource.data.contentMarkdown is string)
+        );
     }
 
     function isValidNoteBase(data) {

--- a/firestore.rules
+++ b/firestore.rules
@@ -20,8 +20,11 @@ service cloud.firestore {
         && list.size() == list.where(item, item is string && item.size() >= minLen && item.size() <= maxLen).size();
     }
 
-    function isBoundedStringList(list, maxItems, minLen, maxLen) {
-      return isStringList(list, minLen, maxLen) && list.size() <= maxItems;
+    function isOptionalBoundedStringList(field, maxItems, minLen, maxLen) {
+      return field == null
+        || (field is list
+          && field.size() <= maxItems
+          && field.size() == field.where(item, item is string && item.size() >= minLen && item.size() <= maxLen).size());
     }
 
     function isTimestamp(value) {
@@ -46,10 +49,17 @@ service cloud.firestore {
         && (!("contentMarkdown" in data) || isString(data.contentMarkdown, 60000))
         && ("description" in data ? isOptionalString(data.description, 300) : true)
         && ("isFavorite" in data ? data.isFavorite is bool : true)
-        && ("category" in data ? (data.category == null || data.category in ["general", "progress", "insight", "reference"]) : true)
-        && (!("tags" in data) || isStringList(data.tags, 1, 50))
-        && (!("linkedCabinetIds" in data) || isBoundedStringList(data.linkedCabinetIds, 50, 1, 100))
-        && (!("linkedItemIds" in data) || isBoundedStringList(data.linkedItemIds, 50, 1, 100))
+        && (
+          "category" in data
+            ? (data.category == null
+                || data.category in ["general", "progress", "insight", "reference"])
+            : true
+        )
+        && (!("tags" in data) || isOptionalBoundedStringList(data.tags, 500, 1, 100))
+        && (!("linkedCabinetIds" in data)
+            || isOptionalBoundedStringList(data.linkedCabinetIds, 50, 1, 100))
+        && (!("linkedItemIds" in data)
+            || isOptionalBoundedStringList(data.linkedItemIds, 50, 1, 100))
         && isTimestamp(data.createdAt)
         && isTimestamp(data.updatedAt);
     }

--- a/src/app/api/open-graph/route.ts
+++ b/src/app/api/open-graph/route.ts
@@ -24,6 +24,14 @@ const META_TITLE_PRIORITY = [
   "title",
 ];
 
+const META_DESCRIPTION_PRIORITY = [
+  "og:description",
+  "twitter:description",
+  "description",
+];
+
+const META_SITE_NAME_KEYS = ["og:site_name", "og:site-name", "og:site"];
+
 function extractAttribute(tag: string, attribute: string): string | null {
   const regex = new RegExp(
     `${attribute}\\s*=\\s*("([^"]*)"|'([^']*)'|([^\"'\s>]+))`,
@@ -135,6 +143,32 @@ function pickMetaTitle(
   return null;
 }
 
+function pickMetaDescription(metaTags: Map<string, string>): string | null {
+  for (const key of META_DESCRIPTION_PRIORITY) {
+    const value = metaTags.get(key);
+    if (value) {
+      const normalized = value.trim();
+      if (normalized) {
+        return normalized;
+      }
+    }
+  }
+  return null;
+}
+
+function pickMetaSiteName(metaTags: Map<string, string>): string | null {
+  for (const key of META_SITE_NAME_KEYS) {
+    const value = metaTags.get(key);
+    if (value) {
+      const normalized = value.trim();
+      if (normalized) {
+        return normalized;
+      }
+    }
+  }
+  return null;
+}
+
 async function readBodyWithLimit(response: Response): Promise<string> {
   if (!response.body) {
     return "";
@@ -217,6 +251,13 @@ export async function GET(request: NextRequest) {
   const metaTags = collectMetaTags(html);
   const imageUrl = pickMetaImage(html, targetUrl, metaTags);
   const title = pickMetaTitle(html, metaTags);
-  return Response.json({ image: imageUrl ?? null, title: title ?? null });
+  const description = pickMetaDescription(metaTags);
+  const siteName = pickMetaSiteName(metaTags);
+  return Response.json({
+    image: imageUrl ?? null,
+    title: title ?? null,
+    description: description ?? null,
+    siteName: siteName ?? null,
+  });
 }
 

--- a/src/app/item/[id]/page.tsx
+++ b/src/app/item/[id]/page.tsx
@@ -36,7 +36,6 @@ import {
 } from "@/lib/insights";
 import { getFirebaseAuth, getFirebaseDb } from "@/lib/firebase";
 import { calculateNextUpdateDate } from "@/lib/item-utils";
-import { NOTE_CATEGORY_OPTIONS, type NoteCategory } from "@/lib/note";
 import { buttonClass } from "@/lib/ui";
 import {
   ITEM_LANGUAGE_OPTIONS,
@@ -75,10 +74,6 @@ const updateFrequencyLabelMap = new Map(
 
 const progressTypeLabelMap = new Map(
   PROGRESS_TYPE_OPTIONS.map((option) => [option.value, option.label])
-);
-
-const noteCategoryLabelMap = new Map(
-  NOTE_CATEGORY_OPTIONS.map((option) => [option.value, option.label])
 );
 
 const backButtonClass =
@@ -189,7 +184,6 @@ type LinkedNote = {
   id: string;
   title: string;
   summary: string | null;
-  category: NoteCategory;
   tags: string[];
   updatedMs: number;
   isFavorite: boolean;
@@ -768,11 +762,6 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
             const updatedAt = data?.updatedAt;
             const updatedMs =
               updatedAt instanceof Timestamp ? updatedAt.toMillis() : Date.now();
-            const categoryValue =
-              typeof data?.category === "string" &&
-              NOTE_CATEGORY_OPTIONS.some((option) => option.value === data.category)
-                ? (data.category as NoteCategory)
-                : "general";
             const tags = Array.isArray(data?.tags)
               ? data.tags.filter((value: unknown): value is string => typeof value === "string")
               : [];
@@ -783,7 +772,6 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
                 typeof data?.description === "string" && data.description.trim().length > 0
                   ? data.description.trim()
                   : null,
-              category: categoryValue,
               tags,
               updatedMs,
               isFavorite: Boolean(data?.isFavorite),
@@ -2863,9 +2851,6 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
                         <p className="break-anywhere text-sm text-gray-600">{note.summary}</p>
                       ) : null}
                       <div className="flex flex-wrap items-center gap-2 text-xs text-gray-500">
-                        <span className="inline-flex items-center rounded-full bg-indigo-50 px-2 py-1 font-medium text-indigo-600">
-                          {noteCategoryLabelMap.get(note.category) ?? "一般筆記"}
-                        </span>
                         <span>
                           更新：{formatDateTime(Timestamp.fromMillis(note.updatedMs))}
                         </span>

--- a/src/app/notes/[id]/edit/page.tsx
+++ b/src/app/notes/[id]/edit/page.tsx
@@ -2,12 +2,24 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { FormEvent, use, useEffect, useState } from "react";
+import { FormEvent, use, useEffect, useMemo, useState } from "react";
 import { onAuthStateChanged, type User } from "firebase/auth";
-import { doc, getDoc, serverTimestamp, updateDoc, type Firestore } from "firebase/firestore";
+import {
+  collection,
+  doc,
+  getDoc,
+  onSnapshot,
+  query,
+  serverTimestamp,
+  updateDoc,
+  where,
+  type Firestore,
+} from "firebase/firestore";
 
 import { RichTextEditor, extractPlainTextFromHtml } from "@/components/RichTextEditor";
 import { getFirebaseAuth, getFirebaseDb } from "@/lib/firebase";
+import { markdownPreviewHtml, simpleMarkdownToHtml, splitTags } from "@/lib/markdown";
+import { NOTE_CATEGORY_OPTIONS, NOTE_TAG_LIMIT, type NoteCategory } from "@/lib/note";
 import { buttonClass } from "@/lib/ui";
 
 const TITLE_LIMIT = 100;
@@ -22,6 +34,17 @@ type PageProps = {
   params: Promise<{ id: string }>;
 };
 
+type CabinetOption = {
+  id: string;
+  name: string;
+};
+
+type ItemOption = {
+  id: string;
+  title: string;
+  cabinetId: string | null;
+};
+
 export default function EditNotePage({ params }: PageProps) {
   const { id: noteId } = use(params);
   const router = useRouter();
@@ -32,6 +55,16 @@ export default function EditNotePage({ params }: PageProps) {
   const [contentHtml, setContentHtml] = useState("");
   const [contentText, setContentText] = useState("");
   const [isFavorite, setIsFavorite] = useState(false);
+  const [markdownContent, setMarkdownContent] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState<NoteCategory>("general");
+  const [cabinetOptions, setCabinetOptions] = useState<CabinetOption[]>([]);
+  const [itemOptions, setItemOptions] = useState<ItemOption[]>([]);
+  const [cabinetSearchTerm, setCabinetSearchTerm] = useState("");
+  const [itemSearchTerm, setItemSearchTerm] = useState("");
+  const [selectedCabinetIds, setSelectedCabinetIds] = useState<string[]>([]);
+  const [selectedItemIds, setSelectedItemIds] = useState<string[]>([]);
+  const [tagInput, setTagInput] = useState("");
+  const [tags, setTags] = useState<string[]>([]);
   const [feedback, setFeedback] = useState<Feedback | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -51,6 +84,141 @@ export default function EditNotePage({ params }: PageProps) {
     });
     return () => unsub();
   }, []);
+
+  useEffect(() => {
+    if (!user) {
+      setCabinetOptions([]);
+      setItemOptions([]);
+      return;
+    }
+    const db = getFirebaseDb();
+    if (!db) {
+      setFeedback({ type: "error", message: "Firebase 尚未設定" });
+      return;
+    }
+    const cabinetQuery = query(collection(db, "cabinet"), where("uid", "==", user.uid));
+    const itemQuery = query(collection(db, "item"), where("uid", "==", user.uid));
+
+    const unsubscribeCabinet = onSnapshot(
+      cabinetQuery,
+      (snapshot) => {
+        setCabinetOptions(
+          snapshot.docs
+            .map((docSnap) => {
+              const data = docSnap.data();
+              return {
+                id: docSnap.id,
+                name: typeof data?.name === "string" ? data.name : "未命名櫃子",
+              } satisfies CabinetOption;
+            })
+            .sort((a, b) => a.name.localeCompare(b.name, "zh-Hant"))
+        );
+      },
+      () => {
+        setFeedback({ type: "error", message: "載入櫃子清單時發生錯誤" });
+      }
+    );
+
+    const unsubscribeItem = onSnapshot(
+      itemQuery,
+      (snapshot) => {
+        setItemOptions(
+          snapshot.docs
+            .map((docSnap) => {
+              const data = docSnap.data();
+              return {
+                id: docSnap.id,
+                title:
+                  typeof data?.titleZh === "string" && data.titleZh.trim()
+                    ? (data.titleZh as string)
+                    : "未命名作品",
+                cabinetId:
+                  typeof data?.cabinetId === "string" && data.cabinetId.trim().length > 0
+                    ? (data.cabinetId as string)
+                    : null,
+              } satisfies ItemOption;
+            })
+            .sort((a, b) => a.title.localeCompare(b.title, "zh-Hant"))
+        );
+      },
+      () => {
+        setFeedback({ type: "error", message: "載入作品清單時發生錯誤" });
+      }
+    );
+
+    return () => {
+      unsubscribeCabinet();
+      unsubscribeItem();
+    };
+  }, [user]);
+
+  useEffect(() => {
+    setSelectedCabinetIds((prev) =>
+      prev.filter((id) => cabinetOptions.some((option) => option.id === id))
+    );
+  }, [cabinetOptions]);
+
+  useEffect(() => {
+    setSelectedItemIds((prev) => prev.filter((id) => itemOptions.some((option) => option.id === id)));
+  }, [itemOptions]);
+
+  const filteredCabinetOptions = useMemo(() => {
+    const keyword = cabinetSearchTerm.trim().toLowerCase();
+    if (!keyword) {
+      return cabinetOptions;
+    }
+    return cabinetOptions.filter((option) => option.name.toLowerCase().includes(keyword));
+  }, [cabinetOptions, cabinetSearchTerm]);
+
+  const filteredItemOptions = useMemo(() => {
+    const keyword = itemSearchTerm.trim().toLowerCase();
+    if (!keyword) {
+      return itemOptions;
+    }
+    return itemOptions.filter((option) => option.title.toLowerCase().includes(keyword));
+  }, [itemOptions, itemSearchTerm]);
+
+  const markdownPreview = useMemo(() => markdownPreviewHtml(markdownContent), [markdownContent]);
+
+  function toggleCabinetSelection(id: string) {
+    setSelectedCabinetIds((prev) =>
+      prev.includes(id) ? prev.filter((value) => value !== id) : [...prev, id]
+    );
+  }
+
+  function toggleItemSelection(id: string) {
+    setSelectedItemIds((prev) =>
+      prev.includes(id) ? prev.filter((value) => value !== id) : [...prev, id]
+    );
+  }
+
+  function handleAddTags() {
+    const newTags = splitTags(tagInput);
+    if (newTags.length === 0) {
+      setTagInput("");
+      return;
+    }
+    setTags((prev) => {
+      const merged = [...prev];
+      for (const tag of newTags) {
+        if (!merged.includes(tag) && merged.length < NOTE_TAG_LIMIT) {
+          merged.push(tag);
+        }
+      }
+      return merged;
+    });
+    setTagInput("");
+  }
+
+  function handleRemoveTag(tag: string) {
+    setTags((prev) => prev.filter((item) => item !== tag));
+  }
+
+  function handleSyncMarkdownToEditor() {
+    const html = simpleMarkdownToHtml(markdownContent);
+    setContentHtml(html);
+    setContentText(extractPlainTextFromHtml(html));
+  }
 
   useEffect(() => {
     if (!authChecked) {
@@ -87,6 +255,11 @@ export default function EditNotePage({ params }: PageProps) {
           setContentHtml("");
           setContentText("");
           setIsFavorite(false);
+          setMarkdownContent("");
+          setSelectedCategory("general");
+          setSelectedCabinetIds([]);
+          setSelectedItemIds([]);
+          setTags([]);
           setLoading(false);
           return;
         }
@@ -99,6 +272,11 @@ export default function EditNotePage({ params }: PageProps) {
           setContentHtml("");
           setContentText("");
           setIsFavorite(false);
+          setMarkdownContent("");
+          setSelectedCategory("general");
+          setSelectedCabinetIds([]);
+          setSelectedItemIds([]);
+          setTags([]);
           setLoading(false);
           return;
         }
@@ -108,6 +286,30 @@ export default function EditNotePage({ params }: PageProps) {
         setContentHtml(noteContent);
         setContentText(extractPlainTextFromHtml(noteContent));
         setIsFavorite(Boolean(data.isFavorite));
+        setMarkdownContent(typeof data.contentMarkdown === "string" ? data.contentMarkdown : "");
+        setSelectedCategory(
+          typeof data.category === "string" &&
+            NOTE_CATEGORY_OPTIONS.some((item) => item.value === data.category)
+            ? (data.category as NoteCategory)
+            : "general"
+        );
+        setSelectedCabinetIds(
+          Array.isArray(data.linkedCabinetIds)
+            ? data.linkedCabinetIds.filter((value): value is string => typeof value === "string")
+            : []
+        );
+        setSelectedItemIds(
+          Array.isArray(data.linkedItemIds)
+            ? data.linkedItemIds.filter((value): value is string => typeof value === "string")
+            : []
+        );
+        setTags(
+          Array.isArray(data.tags)
+            ? data.tags
+                .filter((value): value is string => typeof value === "string")
+                .slice(0, NOTE_TAG_LIMIT)
+            : []
+        );
         setFeedback(null);
         setNotFound(false);
       } catch (err) {
@@ -119,6 +321,11 @@ export default function EditNotePage({ params }: PageProps) {
         setContentHtml("");
         setContentText("");
         setIsFavorite(false);
+        setMarkdownContent("");
+        setSelectedCategory("general");
+        setSelectedCabinetIds([]);
+        setSelectedItemIds([]);
+        setTags([]);
       } finally {
         setLoading(false);
       }
@@ -151,8 +358,9 @@ export default function EditNotePage({ params }: PageProps) {
       setFeedback({ type: "error", message: `備註長度不可超過 ${DESCRIPTION_LIMIT} 字` });
       return;
     }
-    if (!trimmedContentText) {
-      setFeedback({ type: "error", message: "請填寫筆記內容" });
+    const markdownValue = markdownContent.trim();
+    if (!trimmedContentText && !markdownValue) {
+      setFeedback({ type: "error", message: "請填寫筆記內容或 Markdown" });
       return;
     }
 
@@ -174,6 +382,11 @@ export default function EditNotePage({ params }: PageProps) {
         title: trimmedTitle,
         description: trimmedDescription ? trimmedDescription : null,
         content: sanitizedContentHtml,
+        contentMarkdown: markdownValue ? markdownValue : null,
+        category: selectedCategory || null,
+        tags,
+        linkedCabinetIds: selectedCabinetIds,
+        linkedItemIds: selectedItemIds,
         isFavorite,
         updatedAt: serverTimestamp(),
       });
@@ -289,6 +502,140 @@ export default function EditNotePage({ params }: PageProps) {
                 {description.trim().length}/{DESCRIPTION_LIMIT}
               </span>
             </label>
+            <label className="block space-y-2">
+              <span className="text-sm font-medium text-gray-700">筆記類別</span>
+              <select
+                value={selectedCategory}
+                onChange={(event) =>
+                  setSelectedCategory(event.target.value as NoteCategory)
+                }
+                className="h-12 w-full rounded-xl border bg-white px-4 text-base"
+              >
+                {NOTE_CATEGORY_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <div className="space-y-2">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <span className="text-sm font-medium text-gray-700">標籤</span>
+                <span className="text-xs text-gray-400">最多 {NOTE_TAG_LIMIT} 個，使用逗號或空白分隔</span>
+              </div>
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                <input
+                  value={tagInput}
+                  onChange={(event) => setTagInput(event.target.value)}
+                  placeholder="輸入標籤後按新增"
+                  className="h-11 flex-1 rounded-xl border px-4 text-base"
+                />
+                <button
+                  type="button"
+                  onClick={handleAddTags}
+                  className={`${buttonClass({ variant: "secondary", size: "sm" })} w-full sm:w-auto`}
+                >
+                  新增標籤
+                </button>
+              </div>
+              {tags.length > 0 ? (
+                <div className="flex flex-wrap gap-2">
+                  {tags.map((tag) => (
+                    <button
+                      key={tag}
+                      type="button"
+                      onClick={() => handleRemoveTag(tag)}
+                      className="group inline-flex items-center gap-1 rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-700 transition hover:bg-gray-200"
+                    >
+                      <span>#{tag}</span>
+                      <span className="text-xs text-gray-400 group-hover:text-gray-600">刪除</span>
+                    </button>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-gray-500">尚未新增標籤，可用來分類或搜尋。</p>
+              )}
+            </div>
+            <section className="space-y-4 rounded-xl border border-gray-200 bg-white/50 p-4">
+              <header className="space-y-1">
+                <h2 className="text-sm font-medium text-gray-700">連結目標</h2>
+                <p className="text-xs text-gray-500">調整筆記與櫃子、作品的關聯，方便在各頁面互相串連。</p>
+              </header>
+              <div className="space-y-3">
+                <div className="space-y-2">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <span className="text-sm font-medium text-gray-700">櫃子</span>
+                    <input
+                      value={cabinetSearchTerm}
+                      onChange={(event) => setCabinetSearchTerm(event.target.value)}
+                      placeholder="搜尋櫃子"
+                      className="h-10 w-full max-w-xs rounded-xl border px-3 text-sm"
+                    />
+                  </div>
+                  <div className="max-h-40 space-y-1 overflow-auto rounded-lg border border-gray-200 bg-white/60 p-2 text-sm">
+                    {filteredCabinetOptions.length > 0 ? (
+                      filteredCabinetOptions.map((option) => (
+                        <label
+                          key={option.id}
+                          className="flex items-center gap-2 rounded-md px-2 py-1 transition hover:bg-gray-100"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={selectedCabinetIds.includes(option.id)}
+                            onChange={() => toggleCabinetSelection(option.id)}
+                            className="h-4 w-4 rounded border-gray-300 text-indigo-500 focus:ring-indigo-400"
+                          />
+                          <span className="flex-1 break-anywhere">{option.name}</span>
+                        </label>
+                      ))
+                    ) : (
+                      <p className="px-2 py-1 text-xs text-gray-500">尚無櫃子或無符合條件的結果。</p>
+                    )}
+                  </div>
+                </div>
+                <div className="space-y-2">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <span className="text-sm font-medium text-gray-700">作品</span>
+                    <input
+                      value={itemSearchTerm}
+                      onChange={(event) => setItemSearchTerm(event.target.value)}
+                      placeholder="搜尋作品名稱"
+                      className="h-10 w-full max-w-xs rounded-xl border px-3 text-sm"
+                    />
+                  </div>
+                  <div className="max-h-48 space-y-1 overflow-auto rounded-lg border border-gray-200 bg-white/60 p-2 text-sm">
+                    {filteredItemOptions.length > 0 ? (
+                      filteredItemOptions.map((option) => {
+                        const cabinetLabel = option.cabinetId
+                          ? cabinetOptions.find((cabinet) => cabinet.id === option.cabinetId)?.name
+                          : null;
+                        return (
+                          <label
+                            key={option.id}
+                            className="flex items-center gap-2 rounded-md px-2 py-1 transition hover:bg-gray-100"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={selectedItemIds.includes(option.id)}
+                              onChange={() => toggleItemSelection(option.id)}
+                              className="h-4 w-4 rounded border-gray-300 text-indigo-500 focus:ring-indigo-400"
+                            />
+                            <span className="flex-1 break-anywhere">
+                              {option.title}
+                              {cabinetLabel ? (
+                                <span className="ml-1 text-xs text-gray-500">（{cabinetLabel}）</span>
+                              ) : null}
+                            </span>
+                          </label>
+                        );
+                      })
+                    ) : (
+                      <p className="px-2 py-1 text-xs text-gray-500">尚無作品或無符合條件的結果。</p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </section>
             <label className="flex items-center gap-2 text-sm text-gray-700">
               <input
                 type="checkbox"
@@ -298,6 +645,34 @@ export default function EditNotePage({ params }: PageProps) {
               />
               設為最愛
             </label>
+            <div className="space-y-2">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <span className="text-sm font-medium text-gray-700">Markdown 內容（選填）</span>
+                <button
+                  type="button"
+                  onClick={handleSyncMarkdownToEditor}
+                  className={buttonClass({ variant: "secondary", size: "sm" })}
+                >
+                  以 Markdown 更新富文本
+                </button>
+              </div>
+              <textarea
+                value={markdownContent}
+                onChange={(event) => setMarkdownContent(event.target.value)}
+                placeholder="輸入 Markdown 文字，將在下方顯示即時預覽"
+                className="min-h-[140px] w-full resize-y rounded-xl border px-4 py-3 text-base"
+              />
+              <div className="space-y-2 rounded-xl border border-gray-200 bg-white/70 p-4">
+                <div className="flex items-center justify-between text-sm text-gray-600">
+                  <span>Markdown 預覽</span>
+                  <span>{markdownContent.trim().length} 字</span>
+                </div>
+                <div
+                  className="markdown-preview text-sm leading-relaxed text-gray-700"
+                  dangerouslySetInnerHTML={{ __html: markdownPreview }}
+                />
+              </div>
+            </div>
             <div className="space-y-2">
               <span className="text-sm font-medium text-gray-700">筆記內容</span>
               <RichTextEditor

--- a/src/app/notes/[id]/edit/page.tsx
+++ b/src/app/notes/[id]/edit/page.tsx
@@ -18,7 +18,7 @@ import { RichTextEditor, extractPlainTextFromHtml } from "@/components/RichTextE
 import LinkTargetSelector from "@/components/LinkTargetSelector";
 import { getFirebaseAuth, getFirebaseDb } from "@/lib/firebase";
 import { markdownPreviewHtml, simpleMarkdownToHtml } from "@/lib/markdown";
-import { NOTE_TAG_LIMIT, normalizeNoteTags } from "@/lib/note";
+import { normalizeNoteTags } from "@/lib/note";
 import { buttonClass } from "@/lib/ui";
 
 const TITLE_LIMIT = 100;
@@ -152,14 +152,6 @@ export default function EditNotePage({ params }: PageProps) {
       setTagQuery("");
       return;
     }
-    if (tags.length >= NOTE_TAG_LIMIT) {
-      setTagStatus({
-        message: null,
-        error: `最多可選擇 ${NOTE_TAG_LIMIT} 個標籤`,
-        saving: false,
-      });
-      return;
-    }
     if (!user) {
       setTagStatus({ message: null, error: "請先登入", saving: false });
       return;
@@ -280,11 +272,7 @@ export default function EditNotePage({ params }: PageProps) {
             ? data.linkedItemIds.filter((value): value is string => typeof value === "string")
             : []
         );
-        setTags(
-          Array.isArray(data.tags)
-            ? normalizeNoteTags(data.tags).slice(0, NOTE_TAG_LIMIT)
-            : []
-        );
+        setTags(Array.isArray(data.tags) ? normalizeNoteTags(data.tags) : []);
         setTagStatus({ message: null, error: null, saving: false });
         setFeedback(null);
         setNotFound(false);
@@ -482,7 +470,7 @@ export default function EditNotePage({ params }: PageProps) {
               <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                 <div className="space-y-1">
                   <span className="text-sm font-medium text-gray-700">標籤</span>
-                  <span className="text-xs text-gray-400">最多 {NOTE_TAG_LIMIT} 個，可使用 Enter 或逗號快速新增。</span>
+                  <span className="text-xs text-gray-400">可使用 Enter 或逗號快速新增。</span>
                 </div>
                 <div className="flex flex-wrap gap-2">
                   <button

--- a/src/app/notes/[id]/page.tsx
+++ b/src/app/notes/[id]/page.tsx
@@ -4,9 +4,21 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { use, useEffect, useMemo, useState } from "react";
 import { onAuthStateChanged, type User } from "firebase/auth";
-import { deleteDoc, doc, onSnapshot, serverTimestamp, Timestamp, updateDoc } from "firebase/firestore";
+import {
+  collection,
+  deleteDoc,
+  doc,
+  onSnapshot,
+  query,
+  serverTimestamp,
+  Timestamp,
+  updateDoc,
+  where,
+} from "firebase/firestore";
 
 import { getFirebaseAuth, getFirebaseDb } from "@/lib/firebase";
+import { markdownPreviewHtml } from "@/lib/markdown";
+import { NOTE_CATEGORY_OPTIONS, type NoteCategory } from "@/lib/note";
 import { buttonClass } from "@/lib/ui";
 
 type PageProps = {
@@ -18,9 +30,25 @@ type Note = {
   title: string;
   description: string | null;
   content: string;
+  contentMarkdown: string | null;
+  category: NoteCategory;
+  tags: string[];
+  linkedCabinetIds: string[];
+  linkedItemIds: string[];
   isFavorite: boolean;
   createdMs: number;
   updatedMs: number;
+};
+
+type CabinetOption = {
+  id: string;
+  name: string;
+};
+
+type ItemOption = {
+  id: string;
+  title: string;
+  cabinetId: string | null;
 };
 
 type Feedback = {
@@ -57,6 +85,9 @@ export default function NoteDetailPage({ params }: PageProps) {
   const [loading, setLoading] = useState(true);
   const [deleting, setDeleting] = useState(false);
   const [favoriting, setFavoriting] = useState(false);
+  const [cabinetOptions, setCabinetOptions] = useState<CabinetOption[]>([]);
+  const [itemOptions, setItemOptions] = useState<ItemOption[]>([]);
+  const [viewMode, setViewMode] = useState<"rich" | "markdown">("rich");
 
   useEffect(() => {
     const auth = getFirebaseAuth();
@@ -73,6 +104,73 @@ export default function NoteDetailPage({ params }: PageProps) {
     });
     return () => unsub();
   }, []);
+
+  useEffect(() => {
+    if (!user) {
+      setCabinetOptions([]);
+      setItemOptions([]);
+      return;
+    }
+    const db = getFirebaseDb();
+    if (!db) {
+      setFeedback({ type: "error", message: "Firebase 尚未設定" });
+      return;
+    }
+    const cabinetQuery = query(collection(db, "cabinet"), where("uid", "==", user.uid));
+    const itemQuery = query(collection(db, "item"), where("uid", "==", user.uid));
+
+    const unsubCabinet = onSnapshot(
+      cabinetQuery,
+      (snapshot) => {
+        setCabinetOptions(
+          snapshot.docs
+            .map((docSnap) => {
+              const data = docSnap.data();
+              return {
+                id: docSnap.id,
+                name: typeof data?.name === "string" ? data.name : "未命名櫃子",
+              } satisfies CabinetOption;
+            })
+            .sort((a, b) => a.name.localeCompare(b.name, "zh-Hant"))
+        );
+      },
+      () => {
+        setFeedback({ type: "error", message: "載入櫃子資訊時發生錯誤" });
+      }
+    );
+
+    const unsubItem = onSnapshot(
+      itemQuery,
+      (snapshot) => {
+        setItemOptions(
+          snapshot.docs
+            .map((docSnap) => {
+              const data = docSnap.data();
+              return {
+                id: docSnap.id,
+                title:
+                  typeof data?.titleZh === "string" && data.titleZh.trim()
+                    ? (data.titleZh as string)
+                    : "未命名作品",
+                cabinetId:
+                  typeof data?.cabinetId === "string" && data.cabinetId.trim().length > 0
+                    ? (data.cabinetId as string)
+                    : null,
+              } satisfies ItemOption;
+            })
+            .sort((a, b) => a.title.localeCompare(b.title, "zh-Hant"))
+        );
+      },
+      () => {
+        setFeedback({ type: "error", message: "載入作品資訊時發生錯誤" });
+      }
+    );
+
+    return () => {
+      unsubCabinet();
+      unsubItem();
+    };
+  }, [user]);
 
   useEffect(() => {
     if (!authChecked) {
@@ -113,6 +211,24 @@ export default function NoteDetailPage({ params }: PageProps) {
         const updatedAt = data.updatedAt;
         const createdMs = createdAt instanceof Timestamp ? createdAt.toMillis() : 0;
         const updatedMs = updatedAt instanceof Timestamp ? updatedAt.toMillis() : createdMs;
+        const markdownContent =
+          typeof data.contentMarkdown === "string" && data.contentMarkdown.trim().length > 0
+            ? data.contentMarkdown
+            : null;
+        const categoryValue =
+          typeof data.category === "string" &&
+          NOTE_CATEGORY_OPTIONS.some((item) => item.value === data.category)
+            ? (data.category as NoteCategory)
+            : "general";
+        const tags = Array.isArray(data.tags)
+          ? data.tags.filter((value): value is string => typeof value === "string")
+          : [];
+        const linkedCabinetIds = Array.isArray(data.linkedCabinetIds)
+          ? data.linkedCabinetIds.filter((value): value is string => typeof value === "string")
+          : [];
+        const linkedItemIds = Array.isArray(data.linkedItemIds)
+          ? data.linkedItemIds.filter((value): value is string => typeof value === "string")
+          : [];
         setNote({
           id: snap.id,
           title: (data.title as string) || "",
@@ -121,6 +237,11 @@ export default function NoteDetailPage({ params }: PageProps) {
               ? data.description.trim()
               : null,
           content: (data.content as string) || "",
+          contentMarkdown: markdownContent,
+          category: categoryValue,
+          tags,
+          linkedCabinetIds,
+          linkedItemIds,
           isFavorite: Boolean(data.isFavorite),
           createdMs,
           updatedMs,
@@ -136,12 +257,47 @@ export default function NoteDetailPage({ params }: PageProps) {
     return () => unsub();
   }, [authChecked, noteId, user]);
 
+  const categoryLabel = useMemo(() => {
+    if (!note) {
+      return "";
+    }
+    const found = NOTE_CATEGORY_OPTIONS.find((option) => option.value === note.category);
+    return found?.label ?? "一般筆記";
+  }, [note]);
+
+  const linkedCabinets = useMemo(() => {
+    if (!note) {
+      return [] as CabinetOption[];
+    }
+    return note.linkedCabinetIds
+      .map((id) => cabinetOptions.find((option) => option.id === id))
+      .filter((option): option is CabinetOption => Boolean(option));
+  }, [cabinetOptions, note]);
+
+  const linkedItems = useMemo(() => {
+    if (!note) {
+      return [] as ItemOption[];
+    }
+    return note.linkedItemIds
+      .map((id) => itemOptions.find((option) => option.id === id))
+      .filter((option): option is ItemOption => Boolean(option));
+  }, [itemOptions, note]);
+
+  const markdownPreview = useMemo(
+    () => markdownPreviewHtml(note?.contentMarkdown ?? ""),
+    [note?.contentMarkdown]
+  );
+
   const metaInfo = useMemo(() => {
     if (!note) {
       return null;
     }
     return (
       <dl className="grid gap-4 rounded-2xl border border-gray-200 bg-white/60 p-4 text-sm text-gray-600 sm:grid-cols-2">
+        <div className="space-y-1">
+          <dt className="font-medium text-gray-700">筆記類別</dt>
+          <dd>{categoryLabel || "一般筆記"}</dd>
+        </div>
         <div className="space-y-1">
           <dt className="font-medium text-gray-700">建立時間</dt>
           <dd>{formatDateTime(note.createdMs)}</dd>
@@ -152,7 +308,7 @@ export default function NoteDetailPage({ params }: PageProps) {
         </div>
       </dl>
     );
-  }, [note]);
+  }, [categoryLabel, note]);
 
   async function handleDelete() {
     if (!note || deleting) {
@@ -280,14 +436,31 @@ export default function NoteDetailPage({ params }: PageProps) {
                 <h1 className="break-anywhere text-3xl font-semibold text-gray-900">
                   {note.title || "(未命名筆記)"}
                 </h1>
-                {note.isFavorite ? (
-                  <span className="inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-sm font-medium text-amber-700">
-                    最愛
+                <span className="inline-flex items-center gap-2">
+                  {note.isFavorite ? (
+                    <span className="inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-sm font-medium text-amber-700">
+                      最愛
+                    </span>
+                  ) : null}
+                  <span className="inline-flex items-center rounded-full bg-indigo-100 px-3 py-1 text-sm font-medium text-indigo-700">
+                    {categoryLabel || "一般筆記"}
                   </span>
-                ) : null}
+                </span>
               </div>
               {note.description ? (
                 <p className="break-anywhere whitespace-pre-line text-sm text-gray-600">{note.description}</p>
+              ) : null}
+              {note.tags.length > 0 ? (
+                <div className="flex flex-wrap gap-2">
+                  {note.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-700"
+                    >
+                      #{tag}
+                    </span>
+                  ))}
+                </div>
               ) : null}
             </div>
             <div className="flex flex-wrap gap-3 sm:flex-none">
@@ -318,12 +491,118 @@ export default function NoteDetailPage({ params }: PageProps) {
           </div>
         </header>
         {metaInfo}
+        <section className="space-y-4 rounded-2xl border border-gray-200 bg-white/60 p-6 shadow-sm">
+          <h2 className="text-lg font-semibold text-gray-900">整理資訊</h2>
+          <div className="space-y-4 text-sm text-gray-700">
+            <div className="space-y-2">
+              <h3 className="font-medium text-gray-800">標籤</h3>
+              {note.tags.length > 0 ? (
+                <div className="flex flex-wrap gap-2">
+                  {note.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700"
+                    >
+                      #{tag}
+                    </span>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-xs text-gray-500">尚未新增標籤。</p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <h3 className="font-medium text-gray-800">櫃子</h3>
+              {linkedCabinets.length > 0 ? (
+                <ul className="flex flex-wrap gap-2">
+                  {linkedCabinets.map((cabinet) => (
+                    <li key={cabinet.id}>
+                      <Link
+                        href={`/cabinet/${cabinet.id}`}
+                        className="inline-flex items-center rounded-full border border-indigo-100 bg-indigo-50 px-3 py-1 text-xs font-medium text-indigo-700 transition hover:border-indigo-200 hover:bg-indigo-100"
+                      >
+                        {cabinet.name}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-xs text-gray-500">尚未連結任何櫃子。</p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <h3 className="font-medium text-gray-800">作品</h3>
+              {linkedItems.length > 0 ? (
+                <ul className="flex flex-wrap gap-2">
+                  {linkedItems.map((item) => {
+                    const cabinetLabel = item.cabinetId
+                      ? cabinetOptions.find((cabinet) => cabinet.id === item.cabinetId)?.name
+                      : null;
+                    return (
+                      <li key={item.id}>
+                        <Link
+                          href={`/item/${item.id}`}
+                          className="inline-flex items-center rounded-full border border-sky-100 bg-sky-50 px-3 py-1 text-xs font-medium text-sky-700 transition hover:border-sky-200 hover:bg-sky-100"
+                        >
+                          {item.title}
+                          {cabinetLabel ? (
+                            <span className="ml-1 text-[11px] text-sky-600">（{cabinetLabel}）</span>
+                          ) : null}
+                        </Link>
+                      </li>
+                    );
+                  })}
+                </ul>
+              ) : (
+                <p className="text-xs text-gray-500">尚未連結任何作品。</p>
+              )}
+            </div>
+          </div>
+        </section>
         <section className="rounded-2xl border border-gray-200 bg-white/70 p-6 shadow-sm">
-          <h2 className="mb-4 text-lg font-semibold text-gray-900">筆記內容</h2>
-          <div
-            className="rich-text-content text-base leading-relaxed text-gray-700"
-            dangerouslySetInnerHTML={{ __html: note.content }}
-          />
+          <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+            <h2 className="text-lg font-semibold text-gray-900">筆記內容</h2>
+            <div className="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-1 py-1 text-xs">
+              <button
+                type="button"
+                onClick={() => setViewMode("rich")}
+                className={
+                  viewMode === "rich"
+                    ? "rounded-full bg-gray-900 px-3 py-1 font-medium text-white"
+                    : "rounded-full px-3 py-1 text-gray-600 hover:text-gray-800"
+                }
+              >
+                富文本
+              </button>
+              <button
+                type="button"
+                onClick={() => setViewMode("markdown")}
+                className={
+                  viewMode === "markdown"
+                    ? "rounded-full bg-gray-900 px-3 py-1 font-medium text-white"
+                    : "rounded-full px-3 py-1 text-gray-600 hover:text-gray-800"
+                }
+                disabled={!note.contentMarkdown}
+              >
+                Markdown
+              </button>
+            </div>
+          </div>
+          {viewMode === "markdown" ? (
+            note.contentMarkdown ? (
+              <div
+                className="markdown-preview text-base leading-relaxed text-gray-700"
+                dangerouslySetInnerHTML={{ __html: markdownPreview }}
+              />
+            ) : (
+              <p className="text-sm text-gray-500">尚未提供 Markdown 內容，已顯示富文本版本。</p>
+            )
+          ) : (
+            <div
+              className="rich-text-content text-base leading-relaxed text-gray-700"
+              dangerouslySetInnerHTML={{ __html: note.content }}
+            />
+          )}
         </section>
         {feedback && feedback.type === "error" ? (
           <div className="break-anywhere rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">

--- a/src/app/notes/new/page.tsx
+++ b/src/app/notes/new/page.tsx
@@ -2,21 +2,25 @@
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { FormEvent, useEffect, useMemo, useState } from "react";
+import { FormEvent, KeyboardEvent, useEffect, useMemo, useState } from "react";
 import { onAuthStateChanged, type User } from "firebase/auth";
 import {
   addDoc,
   collection,
+  doc,
+  getDoc,
   onSnapshot,
   query,
   serverTimestamp,
+  setDoc,
   where,
 } from "firebase/firestore";
 
 import { RichTextEditor, extractPlainTextFromHtml } from "@/components/RichTextEditor";
+import NoteTagQuickEditor from "@/components/NoteTagQuickEditor";
 import { getFirebaseAuth, getFirebaseDb } from "@/lib/firebase";
-import { markdownPreviewHtml, simpleMarkdownToHtml, splitTags } from "@/lib/markdown";
-import { NOTE_CATEGORY_OPTIONS, NOTE_TAG_LIMIT, type NoteCategory } from "@/lib/note";
+import { markdownPreviewHtml, simpleMarkdownToHtml } from "@/lib/markdown";
+import { NOTE_TAG_LIMIT, normalizeNoteTags } from "@/lib/note";
 import { buttonClass } from "@/lib/ui";
 
 const TITLE_LIMIT = 100;
@@ -43,7 +47,6 @@ export default function NewNotePage() {
   const searchParams = useSearchParams();
   const defaultCabinetId = searchParams.get("cabinetId");
   const defaultItemId = searchParams.get("itemId");
-  const defaultCategory = searchParams.get("category");
   const [user, setUser] = useState<User | null>(null);
   const [authChecked, setAuthChecked] = useState(false);
   const [title, setTitle] = useState("");
@@ -52,11 +55,6 @@ export default function NewNotePage() {
   const [contentText, setContentText] = useState("");
   const [isFavorite, setIsFavorite] = useState(false);
   const [markdownContent, setMarkdownContent] = useState("");
-  const [selectedCategory, setSelectedCategory] = useState<NoteCategory>(
-    defaultCategory && NOTE_CATEGORY_OPTIONS.some((item) => item.value === defaultCategory)
-      ? (defaultCategory as NoteCategory)
-      : "general"
-  );
   const [cabinetOptions, setCabinetOptions] = useState<CabinetOption[]>([]);
   const [itemOptions, setItemOptions] = useState<ItemOption[]>([]);
   const [cabinetSearchTerm, setCabinetSearchTerm] = useState("");
@@ -67,8 +65,15 @@ export default function NewNotePage() {
   const [selectedItemIds, setSelectedItemIds] = useState<string[]>(
     defaultItemId ? [defaultItemId] : []
   );
-  const [tagInput, setTagInput] = useState("");
+  const [tagQuery, setTagQuery] = useState("");
   const [tags, setTags] = useState<string[]>([]);
+  const [noteTags, setNoteTags] = useState<string[]>([]);
+  const [tagStatus, setTagStatus] = useState<{
+    message: string | null;
+    error: string | null;
+    saving: boolean;
+  }>({ message: null, error: null, saving: false });
+  const [tagManagerOpen, setTagManagerOpen] = useState(false);
   const [feedback, setFeedback] = useState<Feedback | null>(null);
   const [saving, setSaving] = useState(false);
 
@@ -90,11 +95,13 @@ export default function NewNotePage() {
     if (!user) {
       setCabinetOptions([]);
       setItemOptions([]);
+      setNoteTags([]);
       return;
     }
     const db = getFirebaseDb();
     if (!db) {
       setFeedback({ type: "error", message: "Firebase 尚未設定" });
+      setNoteTags([]);
       return;
     }
 
@@ -155,6 +162,37 @@ export default function NewNotePage() {
   }, [user]);
 
   useEffect(() => {
+    if (!user) {
+      setNoteTags([]);
+      return;
+    }
+    let active = true;
+    const db = getFirebaseDb();
+    if (!db) {
+      setNoteTags([]);
+      return;
+    }
+    getDoc(doc(db, "user", user.uid))
+      .then((snap) => {
+        if (!active) return;
+        if (!snap.exists()) {
+          setNoteTags([]);
+          return;
+        }
+        const data = snap.data();
+        setNoteTags(normalizeNoteTags(data?.noteTags));
+      })
+      .catch((err) => {
+        if (!active) return;
+        console.error("載入筆記標籤時發生錯誤", err);
+        setNoteTags([]);
+      });
+    return () => {
+      active = false;
+    };
+  }, [user]);
+
+  useEffect(() => {
     setSelectedCabinetIds((prev) =>
       prev.filter((id) => cabinetOptions.some((option) => option.id === id))
     );
@@ -180,6 +218,24 @@ export default function NewNotePage() {
     return itemOptions.filter((option) => option.title.toLowerCase().includes(keyword));
   }, [itemOptions, itemSearchTerm]);
 
+  const selectedTagSet = useMemo(() => new Set(tags), [tags]);
+
+  const availableTagSuggestions = useMemo(
+    () => noteTags.filter((tag) => !selectedTagSet.has(tag)),
+    [noteTags, selectedTagSet]
+  );
+
+  const filteredTagSuggestions = useMemo(() => {
+    const keyword = tagQuery.trim().toLowerCase();
+    const base = availableTagSuggestions;
+    if (!keyword) {
+      return base.slice(0, 20);
+    }
+    return base
+      .filter((tag) => tag.toLowerCase().includes(keyword))
+      .slice(0, 20);
+  }, [availableTagSuggestions, tagQuery]);
+
   const markdownPreview = useMemo(() => markdownPreviewHtml(markdownContent), [markdownContent]);
 
   function toggleCabinetSelection(id: string) {
@@ -194,26 +250,73 @@ export default function NewNotePage() {
     );
   }
 
-  function handleAddTags() {
-    const newTags = splitTags(tagInput);
-    if (newTags.length === 0) {
-      setTagInput("");
+  async function persistUserNoteTags(nextTags: string[]) {
+    if (!user) {
       return;
     }
-    setTags((prev) => {
-      const merged = [...prev];
-      for (const tag of newTags) {
-        if (!merged.includes(tag) && merged.length < NOTE_TAG_LIMIT) {
-          merged.push(tag);
-        }
-      }
-      return merged;
-    });
-    setTagInput("");
+    const db = getFirebaseDb();
+    if (!db) {
+      throw new Error("Firebase 尚未設定");
+    }
+    await setDoc(
+      doc(db, "user", user.uid),
+      { noteTags: nextTags, updatedAt: serverTimestamp() },
+      { merge: true }
+    );
   }
 
-  function handleRemoveTag(tag: string) {
+  async function handleCommitTag(rawTag: string) {
+    const value = rawTag.trim();
+    if (!value) {
+      setTagStatus({ message: null, error: "請輸入標籤名稱", saving: false });
+      return;
+    }
+    if (tags.includes(value)) {
+      setTagStatus({ message: `已選取 #${value}`, error: null, saving: false });
+      setTagQuery("");
+      return;
+    }
+    if (tags.length >= NOTE_TAG_LIMIT) {
+      setTagStatus({
+        message: null,
+        error: `最多可選擇 ${NOTE_TAG_LIMIT} 個標籤`,
+        saving: false,
+      });
+      return;
+    }
+    if (!user) {
+      setTagStatus({ message: null, error: "請先登入", saving: false });
+      return;
+    }
+    setTagStatus({ message: null, error: null, saving: true });
+    setTags((prev) => [...prev, value]);
+    setTagQuery("");
+    try {
+      if (!noteTags.includes(value)) {
+        const nextTags = normalizeNoteTags([...noteTags, value]);
+        await persistUserNoteTags(nextTags);
+        setNoteTags(nextTags);
+        setTagStatus({ message: `已新增 #${value}`, error: null, saving: false });
+      } else {
+        setTagStatus({ message: `已選取 #${value}`, error: null, saving: false });
+      }
+    } catch (err) {
+      console.error("更新筆記標籤時發生錯誤", err);
+      setTags((prev) => prev.filter((tag) => tag !== value));
+      setTagStatus({ message: null, error: "更新標籤時發生錯誤", saving: false });
+    }
+  }
+
+  function handleRemoveSelectedTag(tag: string) {
     setTags((prev) => prev.filter((item) => item !== tag));
+    setTagStatus({ message: `已移除 #${tag}`, error: null, saving: false });
+  }
+
+  function handleTagKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "Enter" || event.key === ",") {
+      event.preventDefault();
+      void handleCommitTag(tagQuery);
+    }
   }
 
   function handleSyncMarkdownToEditor() {
@@ -269,7 +372,6 @@ export default function NewNotePage() {
         description: trimmedDescription ? trimmedDescription : null,
         content: sanitizedContentHtml,
         contentMarkdown: markdownValue ? markdownValue : null,
-        category: selectedCategory || null,
         tags,
         linkedCabinetIds: selectedCabinetIds,
         linkedItemIds: selectedItemIds,
@@ -287,6 +389,8 @@ export default function NewNotePage() {
       setSelectedCabinetIds([]);
       setSelectedItemIds([]);
       setTags([]);
+      setTagQuery("");
+      setTagStatus({ message: null, error: null, saving: false });
       router.replace(`/notes/${docRef.id}`);
     } catch (err) {
       console.error("新增筆記時發生錯誤", err);
@@ -364,59 +468,89 @@ export default function NewNotePage() {
                 {description.trim().length}/{DESCRIPTION_LIMIT}
               </span>
             </label>
-            <label className="block space-y-2">
-              <span className="text-sm font-medium text-gray-700">筆記類別</span>
-              <select
-                value={selectedCategory}
-                onChange={(event) =>
-                  setSelectedCategory(event.target.value as NoteCategory)
-                }
-                className="h-12 w-full rounded-xl border bg-white px-4 text-base"
-              >
-                {NOTE_CATEGORY_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <div className="space-y-2">
+            <div className="space-y-3">
               <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                <span className="text-sm font-medium text-gray-700">標籤</span>
-                <span className="text-xs text-gray-400">最多 {NOTE_TAG_LIMIT} 個，使用逗號或空白分隔</span>
-              </div>
-              <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-                <input
-                  value={tagInput}
-                  onChange={(event) => setTagInput(event.target.value)}
-                  placeholder="輸入標籤後按新增"
-                  className="h-11 flex-1 rounded-xl border px-4 text-base"
-                />
-                <button
-                  type="button"
-                  onClick={handleAddTags}
-                  className={`${buttonClass({ variant: "secondary", size: "sm" })} w-full sm:w-auto`}
-                >
-                  新增標籤
-                </button>
-              </div>
-              {tags.length > 0 ? (
-                <div className="flex flex-wrap gap-2">
-                  {tags.map((tag) => (
-                    <button
-                      key={tag}
-                      type="button"
-                      onClick={() => handleRemoveTag(tag)}
-                      className="group inline-flex items-center gap-1 rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-700 transition hover:bg-gray-200"
-                    >
-                      <span>#{tag}</span>
-                      <span className="text-xs text-gray-400 group-hover:text-gray-600">刪除</span>
-                    </button>
-                  ))}
+                <div className="space-y-1">
+                  <span className="text-sm font-medium text-gray-700">標籤</span>
+                  <span className="text-xs text-gray-400">最多 {NOTE_TAG_LIMIT} 個，可使用 Enter 或逗號快速新增。</span>
                 </div>
-              ) : (
-                <p className="text-sm text-gray-500">尚未新增標籤，可用來分類或搜尋。</p>
-              )}
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setTagManagerOpen(true)}
+                    className={buttonClass({ variant: "secondary", size: "sm" })}
+                  >
+                    筆記標籤管理
+                  </button>
+                </div>
+              </div>
+              <div className="space-y-3 rounded-xl border border-gray-200 bg-white/50 p-4">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                  <input
+                    value={tagQuery}
+                    onChange={(event) => {
+                      setTagQuery(event.target.value);
+                      setTagStatus({ message: null, error: null, saving: false });
+                    }}
+                    onKeyDown={handleTagKeyDown}
+                    placeholder="輸入標籤後按 Enter"
+                    className="h-11 flex-1 rounded-xl border px-4 text-base"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => void handleCommitTag(tagQuery)}
+                    disabled={tagStatus.saving}
+                    className={`${buttonClass({ variant: "secondary", size: "sm" })} w-full sm:w-auto`}
+                  >
+                    新增標籤
+                  </button>
+                </div>
+                {tagStatus.error ? (
+                  <div className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700">{tagStatus.error}</div>
+                ) : null}
+                {tagStatus.message ? (
+                  <div className="rounded-lg bg-emerald-50 px-3 py-2 text-sm text-emerald-700">{tagStatus.message}</div>
+                ) : null}
+                {tags.length > 0 ? (
+                  <div className="flex flex-wrap gap-2">
+                    {tags.map((tag) => (
+                      <button
+                        key={tag}
+                        type="button"
+                        onClick={() => handleRemoveSelectedTag(tag)}
+                        className="group inline-flex items-center gap-1 rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-700 transition hover:bg-gray-200"
+                      >
+                        <span>#{tag}</span>
+                        <span className="text-xs text-gray-400 group-hover:text-gray-600">移除</span>
+                      </button>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-sm text-gray-500">尚未選取任何標籤。</p>
+                )}
+                <div className="space-y-2">
+                  <span className="text-xs font-medium text-gray-500">快速選取</span>
+                  {availableTagSuggestions.length === 0 ? (
+                    <p className="text-xs text-gray-400">尚無可用建議。</p>
+                  ) : filteredTagSuggestions.length === 0 ? (
+                    <p className="text-xs text-gray-400">找不到符合關鍵字的建議標籤。</p>
+                  ) : (
+                    <div className="flex flex-wrap gap-2">
+                      {filteredTagSuggestions.map((tag) => (
+                        <button
+                          key={tag}
+                          type="button"
+                          onClick={() => void handleCommitTag(tag)}
+                          className="inline-flex items-center rounded-full border border-gray-200 bg-white px-3 py-1 text-xs text-gray-600 transition hover:border-gray-300 hover:bg-gray-50"
+                          disabled={tagStatus.saving}
+                        >
+                          #{tag}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
             </div>
             <section className="space-y-4 rounded-xl border border-gray-200 bg-white/50 p-4">
               <header className="space-y-1">
@@ -573,6 +707,31 @@ export default function NewNotePage() {
             </div>
           </form>
         </section>
+        <NoteTagQuickEditor
+          open={tagManagerOpen}
+          onClose={() => setTagManagerOpen(false)}
+          userId={user.uid}
+          tags={noteTags}
+          onTagsChange={(nextTags) => {
+            setNoteTags(nextTags);
+            setTagStatus({ message: null, error: null, saving: false });
+          }}
+          onTagRenamed={(previousTag, nextTag) => {
+            setTags((current) =>
+              current.map((tag) => (tag === previousTag ? nextTag : tag))
+            );
+          }}
+          onTagDeleted={(target) => {
+            setTags((current) => current.filter((tag) => tag !== target));
+          }}
+          onStatus={(status) => {
+            setTagStatus({
+              message: status.message ?? null,
+              error: status.error ?? null,
+              saving: false,
+            });
+          }}
+        />
       </div>
     </main>
   );

--- a/src/app/notes/new/page.tsx
+++ b/src/app/notes/new/page.tsx
@@ -1,17 +1,37 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { FormEvent, useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { FormEvent, useEffect, useMemo, useState } from "react";
 import { onAuthStateChanged, type User } from "firebase/auth";
-import { addDoc, collection, serverTimestamp } from "firebase/firestore";
+import {
+  addDoc,
+  collection,
+  onSnapshot,
+  query,
+  serverTimestamp,
+  where,
+} from "firebase/firestore";
 
-import { RichTextEditor } from "@/components/RichTextEditor";
+import { RichTextEditor, extractPlainTextFromHtml } from "@/components/RichTextEditor";
 import { getFirebaseAuth, getFirebaseDb } from "@/lib/firebase";
+import { markdownPreviewHtml, simpleMarkdownToHtml, splitTags } from "@/lib/markdown";
+import { NOTE_CATEGORY_OPTIONS, NOTE_TAG_LIMIT, type NoteCategory } from "@/lib/note";
 import { buttonClass } from "@/lib/ui";
 
 const TITLE_LIMIT = 100;
 const DESCRIPTION_LIMIT = 300;
+
+type CabinetOption = {
+  id: string;
+  name: string;
+};
+
+type ItemOption = {
+  id: string;
+  title: string;
+  cabinetId: string | null;
+};
 
 type Feedback = {
   type: "error" | "success";
@@ -20,6 +40,10 @@ type Feedback = {
 
 export default function NewNotePage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const defaultCabinetId = searchParams.get("cabinetId");
+  const defaultItemId = searchParams.get("itemId");
+  const defaultCategory = searchParams.get("category");
   const [user, setUser] = useState<User | null>(null);
   const [authChecked, setAuthChecked] = useState(false);
   const [title, setTitle] = useState("");
@@ -27,6 +51,24 @@ export default function NewNotePage() {
   const [contentHtml, setContentHtml] = useState("");
   const [contentText, setContentText] = useState("");
   const [isFavorite, setIsFavorite] = useState(false);
+  const [markdownContent, setMarkdownContent] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState<NoteCategory>(
+    defaultCategory && NOTE_CATEGORY_OPTIONS.some((item) => item.value === defaultCategory)
+      ? (defaultCategory as NoteCategory)
+      : "general"
+  );
+  const [cabinetOptions, setCabinetOptions] = useState<CabinetOption[]>([]);
+  const [itemOptions, setItemOptions] = useState<ItemOption[]>([]);
+  const [cabinetSearchTerm, setCabinetSearchTerm] = useState("");
+  const [itemSearchTerm, setItemSearchTerm] = useState("");
+  const [selectedCabinetIds, setSelectedCabinetIds] = useState<string[]>(
+    defaultCabinetId ? [defaultCabinetId] : []
+  );
+  const [selectedItemIds, setSelectedItemIds] = useState<string[]>(
+    defaultItemId ? [defaultItemId] : []
+  );
+  const [tagInput, setTagInput] = useState("");
+  const [tags, setTags] = useState<string[]>([]);
   const [feedback, setFeedback] = useState<Feedback | null>(null);
   const [saving, setSaving] = useState(false);
 
@@ -43,6 +85,142 @@ export default function NewNotePage() {
     });
     return () => unsub();
   }, []);
+
+  useEffect(() => {
+    if (!user) {
+      setCabinetOptions([]);
+      setItemOptions([]);
+      return;
+    }
+    const db = getFirebaseDb();
+    if (!db) {
+      setFeedback({ type: "error", message: "Firebase 尚未設定" });
+      return;
+    }
+
+    const cabinetQuery = query(collection(db, "cabinet"), where("uid", "==", user.uid));
+    const itemQuery = query(collection(db, "item"), where("uid", "==", user.uid));
+
+    const unsubCabinet = onSnapshot(
+      cabinetQuery,
+      (snapshot) => {
+        setCabinetOptions(
+          snapshot.docs
+            .map((docSnap) => {
+              const data = docSnap.data();
+              return {
+                id: docSnap.id,
+                name: typeof data?.name === "string" ? data.name : "未命名櫃子",
+              } satisfies CabinetOption;
+            })
+            .sort((a, b) => a.name.localeCompare(b.name, "zh-Hant"))
+        );
+      },
+      () => {
+        setFeedback({ type: "error", message: "載入櫃子清單時發生錯誤" });
+      }
+    );
+
+    const unsubItem = onSnapshot(
+      itemQuery,
+      (snapshot) => {
+        setItemOptions(
+          snapshot.docs
+            .map((docSnap) => {
+              const data = docSnap.data();
+              return {
+                id: docSnap.id,
+                title:
+                  typeof data?.titleZh === "string" && data.titleZh.trim()
+                    ? (data.titleZh as string)
+                    : "未命名作品",
+                cabinetId:
+                  typeof data?.cabinetId === "string" && data.cabinetId.trim().length > 0
+                    ? (data.cabinetId as string)
+                    : null,
+              } satisfies ItemOption;
+            })
+            .sort((a, b) => a.title.localeCompare(b.title, "zh-Hant"))
+        );
+      },
+      () => {
+        setFeedback({ type: "error", message: "載入作品清單時發生錯誤" });
+      }
+    );
+
+    return () => {
+      unsubCabinet();
+      unsubItem();
+    };
+  }, [user]);
+
+  useEffect(() => {
+    setSelectedCabinetIds((prev) =>
+      prev.filter((id) => cabinetOptions.some((option) => option.id === id))
+    );
+  }, [cabinetOptions]);
+
+  useEffect(() => {
+    setSelectedItemIds((prev) => prev.filter((id) => itemOptions.some((option) => option.id === id)));
+  }, [itemOptions]);
+
+  const filteredCabinetOptions = useMemo(() => {
+    const keyword = cabinetSearchTerm.trim().toLowerCase();
+    if (!keyword) {
+      return cabinetOptions;
+    }
+    return cabinetOptions.filter((option) => option.name.toLowerCase().includes(keyword));
+  }, [cabinetOptions, cabinetSearchTerm]);
+
+  const filteredItemOptions = useMemo(() => {
+    const keyword = itemSearchTerm.trim().toLowerCase();
+    if (!keyword) {
+      return itemOptions;
+    }
+    return itemOptions.filter((option) => option.title.toLowerCase().includes(keyword));
+  }, [itemOptions, itemSearchTerm]);
+
+  const markdownPreview = useMemo(() => markdownPreviewHtml(markdownContent), [markdownContent]);
+
+  function toggleCabinetSelection(id: string) {
+    setSelectedCabinetIds((prev) =>
+      prev.includes(id) ? prev.filter((value) => value !== id) : [...prev, id]
+    );
+  }
+
+  function toggleItemSelection(id: string) {
+    setSelectedItemIds((prev) =>
+      prev.includes(id) ? prev.filter((value) => value !== id) : [...prev, id]
+    );
+  }
+
+  function handleAddTags() {
+    const newTags = splitTags(tagInput);
+    if (newTags.length === 0) {
+      setTagInput("");
+      return;
+    }
+    setTags((prev) => {
+      const merged = [...prev];
+      for (const tag of newTags) {
+        if (!merged.includes(tag) && merged.length < NOTE_TAG_LIMIT) {
+          merged.push(tag);
+        }
+      }
+      return merged;
+    });
+    setTagInput("");
+  }
+
+  function handleRemoveTag(tag: string) {
+    setTags((prev) => prev.filter((item) => item !== tag));
+  }
+
+  function handleSyncMarkdownToEditor() {
+    const html = simpleMarkdownToHtml(markdownContent);
+    setContentHtml(html);
+    setContentText(extractPlainTextFromHtml(html));
+  }
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -69,8 +247,9 @@ export default function NewNotePage() {
       setFeedback({ type: "error", message: `備註長度不可超過 ${DESCRIPTION_LIMIT} 字` });
       return;
     }
-    if (!trimmedContentText) {
-      setFeedback({ type: "error", message: "請填寫筆記內容" });
+    const markdownValue = markdownContent.trim();
+    if (!trimmedContentText && !markdownValue) {
+      setFeedback({ type: "error", message: "請填寫筆記內容或 Markdown" });
       return;
     }
 
@@ -84,11 +263,16 @@ export default function NewNotePage() {
     setFeedback(null);
 
     try {
-      await addDoc(collection(db, "note"), {
+      const docRef = await addDoc(collection(db, "note"), {
         uid: user.uid,
         title: trimmedTitle,
         description: trimmedDescription ? trimmedDescription : null,
         content: sanitizedContentHtml,
+        contentMarkdown: markdownValue ? markdownValue : null,
+        category: selectedCategory || null,
+        tags,
+        linkedCabinetIds: selectedCabinetIds,
+        linkedItemIds: selectedItemIds,
         isFavorite,
         createdAt: serverTimestamp(),
         updatedAt: serverTimestamp(),
@@ -98,8 +282,12 @@ export default function NewNotePage() {
       setDescription("");
       setContentHtml("");
       setContentText("");
+      setMarkdownContent("");
       setIsFavorite(false);
-      router.replace("/notes");
+      setSelectedCabinetIds([]);
+      setSelectedItemIds([]);
+      setTags([]);
+      router.replace(`/notes/${docRef.id}`);
     } catch (err) {
       console.error("新增筆記時發生錯誤", err);
       setFeedback({ type: "error", message: "新增筆記時發生錯誤" });
@@ -176,6 +364,142 @@ export default function NewNotePage() {
                 {description.trim().length}/{DESCRIPTION_LIMIT}
               </span>
             </label>
+            <label className="block space-y-2">
+              <span className="text-sm font-medium text-gray-700">筆記類別</span>
+              <select
+                value={selectedCategory}
+                onChange={(event) =>
+                  setSelectedCategory(event.target.value as NoteCategory)
+                }
+                className="h-12 w-full rounded-xl border bg-white px-4 text-base"
+              >
+                {NOTE_CATEGORY_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <div className="space-y-2">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <span className="text-sm font-medium text-gray-700">標籤</span>
+                <span className="text-xs text-gray-400">最多 {NOTE_TAG_LIMIT} 個，使用逗號或空白分隔</span>
+              </div>
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                <input
+                  value={tagInput}
+                  onChange={(event) => setTagInput(event.target.value)}
+                  placeholder="輸入標籤後按新增"
+                  className="h-11 flex-1 rounded-xl border px-4 text-base"
+                />
+                <button
+                  type="button"
+                  onClick={handleAddTags}
+                  className={`${buttonClass({ variant: "secondary", size: "sm" })} w-full sm:w-auto`}
+                >
+                  新增標籤
+                </button>
+              </div>
+              {tags.length > 0 ? (
+                <div className="flex flex-wrap gap-2">
+                  {tags.map((tag) => (
+                    <button
+                      key={tag}
+                      type="button"
+                      onClick={() => handleRemoveTag(tag)}
+                      className="group inline-flex items-center gap-1 rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-700 transition hover:bg-gray-200"
+                    >
+                      <span>#{tag}</span>
+                      <span className="text-xs text-gray-400 group-hover:text-gray-600">刪除</span>
+                    </button>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-gray-500">尚未新增標籤，可用來分類或搜尋。</p>
+              )}
+            </div>
+            <section className="space-y-4 rounded-xl border border-gray-200 bg-white/50 p-4">
+              <header className="space-y-1">
+                <h2 className="text-sm font-medium text-gray-700">連結目標</h2>
+                <p className="text-xs text-gray-500">
+                  選擇此筆記要關聯的櫃子或作品，日後可在詳細頁快速切換。
+                </p>
+              </header>
+              <div className="space-y-3">
+                <div className="space-y-2">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <span className="text-sm font-medium text-gray-700">櫃子</span>
+                    <input
+                      value={cabinetSearchTerm}
+                      onChange={(event) => setCabinetSearchTerm(event.target.value)}
+                      placeholder="搜尋櫃子"
+                      className="h-10 w-full max-w-xs rounded-xl border px-3 text-sm"
+                    />
+                  </div>
+                  <div className="max-h-40 space-y-1 overflow-auto rounded-lg border border-gray-200 bg-white/60 p-2 text-sm">
+                    {filteredCabinetOptions.length > 0 ? (
+                      filteredCabinetOptions.map((option) => (
+                        <label
+                          key={option.id}
+                          className="flex items-center gap-2 rounded-md px-2 py-1 transition hover:bg-gray-100"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={selectedCabinetIds.includes(option.id)}
+                            onChange={() => toggleCabinetSelection(option.id)}
+                            className="h-4 w-4 rounded border-gray-300 text-indigo-500 focus:ring-indigo-400"
+                          />
+                          <span className="flex-1 break-anywhere">{option.name}</span>
+                        </label>
+                      ))
+                    ) : (
+                      <p className="px-2 py-1 text-xs text-gray-500">尚無櫃子或無符合條件的結果。</p>
+                    )}
+                  </div>
+                </div>
+                <div className="space-y-2">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <span className="text-sm font-medium text-gray-700">作品</span>
+                    <input
+                      value={itemSearchTerm}
+                      onChange={(event) => setItemSearchTerm(event.target.value)}
+                      placeholder="搜尋作品名稱"
+                      className="h-10 w-full max-w-xs rounded-xl border px-3 text-sm"
+                    />
+                  </div>
+                  <div className="max-h-48 space-y-1 overflow-auto rounded-lg border border-gray-200 bg-white/60 p-2 text-sm">
+                    {filteredItemOptions.length > 0 ? (
+                      filteredItemOptions.map((option) => {
+                        const cabinetLabel = option.cabinetId
+                          ? cabinetOptions.find((cabinet) => cabinet.id === option.cabinetId)?.name
+                          : null;
+                        return (
+                          <label
+                            key={option.id}
+                            className="flex items-center gap-2 rounded-md px-2 py-1 transition hover:bg-gray-100"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={selectedItemIds.includes(option.id)}
+                              onChange={() => toggleItemSelection(option.id)}
+                              className="h-4 w-4 rounded border-gray-300 text-indigo-500 focus:ring-indigo-400"
+                            />
+                            <span className="flex-1 break-anywhere">
+                              {option.title}
+                              {cabinetLabel ? (
+                                <span className="ml-1 text-xs text-gray-500">（{cabinetLabel}）</span>
+                              ) : null}
+                            </span>
+                          </label>
+                        );
+                      })
+                    ) : (
+                      <p className="px-2 py-1 text-xs text-gray-500">尚無作品或無符合條件的結果。</p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </section>
             <label className="flex items-center gap-2 text-sm text-gray-700">
               <input
                 type="checkbox"
@@ -185,6 +509,34 @@ export default function NewNotePage() {
               />
               設為最愛
             </label>
+            <div className="space-y-2">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <span className="text-sm font-medium text-gray-700">Markdown 內容（選填）</span>
+                <button
+                  type="button"
+                  onClick={handleSyncMarkdownToEditor}
+                  className={buttonClass({ variant: "secondary", size: "sm" })}
+                >
+                  以 Markdown 更新富文本
+                </button>
+              </div>
+              <textarea
+                value={markdownContent}
+                onChange={(event) => setMarkdownContent(event.target.value)}
+                placeholder="輸入 Markdown 文字，將在下方顯示即時預覽"
+                className="min-h-[140px] w-full resize-y rounded-xl border px-4 py-3 text-base"
+              />
+              <div className="space-y-2 rounded-xl border border-gray-200 bg-white/70 p-4">
+                <div className="flex items-center justify-between text-sm text-gray-600">
+                  <span>Markdown 預覽</span>
+                  <span>{markdownContent.trim().length} 字</span>
+                </div>
+                <div
+                  className="markdown-preview text-sm leading-relaxed text-gray-700"
+                  dangerouslySetInnerHTML={{ __html: markdownPreview }}
+                />
+              </div>
+            </div>
             <div className="space-y-2">
               <span className="text-sm font-medium text-gray-700">筆記內容</span>
               <RichTextEditor

--- a/src/app/notes/new/page.tsx
+++ b/src/app/notes/new/page.tsx
@@ -9,15 +9,13 @@ import {
   collection,
   doc,
   getDoc,
-  onSnapshot,
-  query,
   serverTimestamp,
   setDoc,
-  where,
 } from "firebase/firestore";
 
 import { RichTextEditor, extractPlainTextFromHtml } from "@/components/RichTextEditor";
 import NoteTagQuickEditor from "@/components/NoteTagQuickEditor";
+import LinkTargetSelector from "@/components/LinkTargetSelector";
 import { getFirebaseAuth, getFirebaseDb } from "@/lib/firebase";
 import { markdownPreviewHtml, simpleMarkdownToHtml } from "@/lib/markdown";
 import { NOTE_TAG_LIMIT, normalizeNoteTags } from "@/lib/note";
@@ -25,17 +23,6 @@ import { buttonClass } from "@/lib/ui";
 
 const TITLE_LIMIT = 100;
 const DESCRIPTION_LIMIT = 300;
-
-type CabinetOption = {
-  id: string;
-  name: string;
-};
-
-type ItemOption = {
-  id: string;
-  title: string;
-  cabinetId: string | null;
-};
 
 type Feedback = {
   type: "error" | "success";
@@ -55,10 +42,6 @@ export default function NewNotePage() {
   const [contentText, setContentText] = useState("");
   const [isFavorite, setIsFavorite] = useState(false);
   const [markdownContent, setMarkdownContent] = useState("");
-  const [cabinetOptions, setCabinetOptions] = useState<CabinetOption[]>([]);
-  const [itemOptions, setItemOptions] = useState<ItemOption[]>([]);
-  const [cabinetSearchTerm, setCabinetSearchTerm] = useState("");
-  const [itemSearchTerm, setItemSearchTerm] = useState("");
   const [selectedCabinetIds, setSelectedCabinetIds] = useState<string[]>(
     defaultCabinetId ? [defaultCabinetId] : []
   );
@@ -93,8 +76,6 @@ export default function NewNotePage() {
 
   useEffect(() => {
     if (!user) {
-      setCabinetOptions([]);
-      setItemOptions([]);
       setNoteTags([]);
       return;
     }
@@ -104,61 +85,6 @@ export default function NewNotePage() {
       setNoteTags([]);
       return;
     }
-
-    const cabinetQuery = query(collection(db, "cabinet"), where("uid", "==", user.uid));
-    const itemQuery = query(collection(db, "item"), where("uid", "==", user.uid));
-
-    const unsubCabinet = onSnapshot(
-      cabinetQuery,
-      (snapshot) => {
-        setCabinetOptions(
-          snapshot.docs
-            .map((docSnap) => {
-              const data = docSnap.data();
-              return {
-                id: docSnap.id,
-                name: typeof data?.name === "string" ? data.name : "未命名櫃子",
-              } satisfies CabinetOption;
-            })
-            .sort((a, b) => a.name.localeCompare(b.name, "zh-Hant"))
-        );
-      },
-      () => {
-        setFeedback({ type: "error", message: "載入櫃子清單時發生錯誤" });
-      }
-    );
-
-    const unsubItem = onSnapshot(
-      itemQuery,
-      (snapshot) => {
-        setItemOptions(
-          snapshot.docs
-            .map((docSnap) => {
-              const data = docSnap.data();
-              return {
-                id: docSnap.id,
-                title:
-                  typeof data?.titleZh === "string" && data.titleZh.trim()
-                    ? (data.titleZh as string)
-                    : "未命名作品",
-                cabinetId:
-                  typeof data?.cabinetId === "string" && data.cabinetId.trim().length > 0
-                    ? (data.cabinetId as string)
-                    : null,
-              } satisfies ItemOption;
-            })
-            .sort((a, b) => a.title.localeCompare(b.title, "zh-Hant"))
-        );
-      },
-      () => {
-        setFeedback({ type: "error", message: "載入作品清單時發生錯誤" });
-      }
-    );
-
-    return () => {
-      unsubCabinet();
-      unsubItem();
-    };
   }, [user]);
 
   useEffect(() => {
@@ -192,32 +118,6 @@ export default function NewNotePage() {
     };
   }, [user]);
 
-  useEffect(() => {
-    setSelectedCabinetIds((prev) =>
-      prev.filter((id) => cabinetOptions.some((option) => option.id === id))
-    );
-  }, [cabinetOptions]);
-
-  useEffect(() => {
-    setSelectedItemIds((prev) => prev.filter((id) => itemOptions.some((option) => option.id === id)));
-  }, [itemOptions]);
-
-  const filteredCabinetOptions = useMemo(() => {
-    const keyword = cabinetSearchTerm.trim().toLowerCase();
-    if (!keyword) {
-      return cabinetOptions;
-    }
-    return cabinetOptions.filter((option) => option.name.toLowerCase().includes(keyword));
-  }, [cabinetOptions, cabinetSearchTerm]);
-
-  const filteredItemOptions = useMemo(() => {
-    const keyword = itemSearchTerm.trim().toLowerCase();
-    if (!keyword) {
-      return itemOptions;
-    }
-    return itemOptions.filter((option) => option.title.toLowerCase().includes(keyword));
-  }, [itemOptions, itemSearchTerm]);
-
   const selectedTagSet = useMemo(() => new Set(tags), [tags]);
 
   const availableTagSuggestions = useMemo(
@@ -237,18 +137,6 @@ export default function NewNotePage() {
   }, [availableTagSuggestions, tagQuery]);
 
   const markdownPreview = useMemo(() => markdownPreviewHtml(markdownContent), [markdownContent]);
-
-  function toggleCabinetSelection(id: string) {
-    setSelectedCabinetIds((prev) =>
-      prev.includes(id) ? prev.filter((value) => value !== id) : [...prev, id]
-    );
-  }
-
-  function toggleItemSelection(id: string) {
-    setSelectedItemIds((prev) =>
-      prev.includes(id) ? prev.filter((value) => value !== id) : [...prev, id]
-    );
-  }
 
   async function persistUserNoteTags(nextTags: string[]) {
     if (!user) {
@@ -398,6 +286,10 @@ export default function NewNotePage() {
     } finally {
       setSaving(false);
     }
+  }
+
+  function handleLinkTargetError(message: string) {
+    setFeedback({ type: "error", message });
   }
 
   if (!authChecked) {
@@ -552,88 +444,14 @@ export default function NewNotePage() {
                 </div>
               </div>
             </div>
-            <section className="space-y-4 rounded-xl border border-gray-200 bg-white/50 p-4">
-              <header className="space-y-1">
-                <h2 className="text-sm font-medium text-gray-700">連結目標</h2>
-                <p className="text-xs text-gray-500">
-                  選擇此筆記要關聯的櫃子或作品，日後可在詳細頁快速切換。
-                </p>
-              </header>
-              <div className="space-y-3">
-                <div className="space-y-2">
-                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                    <span className="text-sm font-medium text-gray-700">櫃子</span>
-                    <input
-                      value={cabinetSearchTerm}
-                      onChange={(event) => setCabinetSearchTerm(event.target.value)}
-                      placeholder="搜尋櫃子"
-                      className="h-10 w-full max-w-xs rounded-xl border px-3 text-sm"
-                    />
-                  </div>
-                  <div className="max-h-40 space-y-1 overflow-auto rounded-lg border border-gray-200 bg-white/60 p-2 text-sm">
-                    {filteredCabinetOptions.length > 0 ? (
-                      filteredCabinetOptions.map((option) => (
-                        <label
-                          key={option.id}
-                          className="flex items-center gap-2 rounded-md px-2 py-1 transition hover:bg-gray-100"
-                        >
-                          <input
-                            type="checkbox"
-                            checked={selectedCabinetIds.includes(option.id)}
-                            onChange={() => toggleCabinetSelection(option.id)}
-                            className="h-4 w-4 rounded border-gray-300 text-indigo-500 focus:ring-indigo-400"
-                          />
-                          <span className="flex-1 break-anywhere">{option.name}</span>
-                        </label>
-                      ))
-                    ) : (
-                      <p className="px-2 py-1 text-xs text-gray-500">尚無櫃子或無符合條件的結果。</p>
-                    )}
-                  </div>
-                </div>
-                <div className="space-y-2">
-                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                    <span className="text-sm font-medium text-gray-700">作品</span>
-                    <input
-                      value={itemSearchTerm}
-                      onChange={(event) => setItemSearchTerm(event.target.value)}
-                      placeholder="搜尋作品名稱"
-                      className="h-10 w-full max-w-xs rounded-xl border px-3 text-sm"
-                    />
-                  </div>
-                  <div className="max-h-48 space-y-1 overflow-auto rounded-lg border border-gray-200 bg-white/60 p-2 text-sm">
-                    {filteredItemOptions.length > 0 ? (
-                      filteredItemOptions.map((option) => {
-                        const cabinetLabel = option.cabinetId
-                          ? cabinetOptions.find((cabinet) => cabinet.id === option.cabinetId)?.name
-                          : null;
-                        return (
-                          <label
-                            key={option.id}
-                            className="flex items-center gap-2 rounded-md px-2 py-1 transition hover:bg-gray-100"
-                          >
-                            <input
-                              type="checkbox"
-                              checked={selectedItemIds.includes(option.id)}
-                              onChange={() => toggleItemSelection(option.id)}
-                              className="h-4 w-4 rounded border-gray-300 text-indigo-500 focus:ring-indigo-400"
-                            />
-                            <span className="flex-1 break-anywhere">
-                              {option.title}
-                              {cabinetLabel ? (
-                                <span className="ml-1 text-xs text-gray-500">（{cabinetLabel}）</span>
-                              ) : null}
-                            </span>
-                          </label>
-                        );
-                      })
-                    ) : (
-                      <p className="px-2 py-1 text-xs text-gray-500">尚無作品或無符合條件的結果。</p>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </section>
+            <LinkTargetSelector
+              userId={user?.uid ?? null}
+              selectedCabinetIds={selectedCabinetIds}
+              onCabinetIdsChange={setSelectedCabinetIds}
+              selectedItemIds={selectedItemIds}
+              onItemIdsChange={setSelectedItemIds}
+              onError={handleLinkTargetError}
+            />
             <label className="flex items-center gap-2 text-sm text-gray-700">
               <input
                 type="checkbox"

--- a/src/app/notes/new/page.tsx
+++ b/src/app/notes/new/page.tsx
@@ -18,7 +18,7 @@ import NoteTagQuickEditor from "@/components/NoteTagQuickEditor";
 import LinkTargetSelector from "@/components/LinkTargetSelector";
 import { getFirebaseAuth, getFirebaseDb } from "@/lib/firebase";
 import { markdownPreviewHtml, simpleMarkdownToHtml } from "@/lib/markdown";
-import { NOTE_TAG_LIMIT, normalizeNoteTags } from "@/lib/note";
+import { normalizeNoteTags } from "@/lib/note";
 import { buttonClass } from "@/lib/ui";
 
 const TITLE_LIMIT = 100;
@@ -162,14 +162,6 @@ export default function NewNotePage() {
     if (tags.includes(value)) {
       setTagStatus({ message: `已選取 #${value}`, error: null, saving: false });
       setTagQuery("");
-      return;
-    }
-    if (tags.length >= NOTE_TAG_LIMIT) {
-      setTagStatus({
-        message: null,
-        error: `最多可選擇 ${NOTE_TAG_LIMIT} 個標籤`,
-        saving: false,
-      });
       return;
     }
     if (!user) {
@@ -364,7 +356,7 @@ export default function NewNotePage() {
               <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                 <div className="space-y-1">
                   <span className="text-sm font-medium text-gray-700">標籤</span>
-                  <span className="text-xs text-gray-400">最多 {NOTE_TAG_LIMIT} 個，可使用 Enter 或逗號快速新增。</span>
+                  <span className="text-xs text-gray-400">可使用 Enter 或逗號快速新增。</span>
                 </div>
                 <div className="flex flex-wrap gap-2">
                   <button

--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { onAuthStateChanged, type User } from "firebase/auth";
 import { collection, doc, getDoc, onSnapshot, query, Timestamp, where } from "firebase/firestore";
 
@@ -66,6 +66,7 @@ function formatDateTime(ms: number): string {
 
 export default function NotesPage() {
   const searchParams = useSearchParams();
+  const router = useRouter();
   const initialCabinetId = searchParams.get("cabinetId");
   const initialItemId = searchParams.get("itemId");
   const initialTag = searchParams.get("tag");
@@ -483,12 +484,17 @@ export default function NotesPage() {
                           🔒 櫃：{name}
                         </button>
                       ) : (
-                        <Link
-                          href={`/cabinet/${cabinetId}`}
+                        <button
+                          type="button"
+                          onClick={(event) => {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            router.push(`/cabinet/${cabinetId}`);
+                          }}
                           className="inline-flex items-center rounded-full bg-indigo-50 px-2 py-1 font-medium text-indigo-600 transition hover:bg-indigo-100"
                         >
                           櫃：{name}
-                        </Link>
+                        </button>
                       )}
                     </span>
                   );
@@ -518,15 +524,20 @@ export default function NotesPage() {
                           ) : null}
                         </button>
                       ) : (
-                        <Link
-                          href={`/item/${option.id}`}
+                        <button
+                          type="button"
+                          onClick={(event) => {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            router.push(`/item/${option.id}`);
+                          }}
                           className="inline-flex items-center rounded-full bg-sky-100 px-2 py-1 font-medium text-sky-600 transition hover:bg-sky-100/80"
                         >
                           作：{option.title}
                           {cabinetLabel ? (
                             <span className="ml-1 text-[11px] text-sky-600">（{cabinetLabel}）</span>
                           ) : null}
-                        </Link>
+                        </button>
                       )}
                     </span>
                   );
@@ -549,7 +560,17 @@ export default function NotesPage() {
         ))}
       </ul>
     );
-  }, [cabinetLockMap, cabinetNameMap, hasFilteredNotes, hasNotes, itemOptionMap, paginatedNotes, showCabinetLockedAlert, showItemLockedAlert]);
+  }, [
+    cabinetLockMap,
+    cabinetNameMap,
+    hasFilteredNotes,
+    hasNotes,
+    itemOptionMap,
+    paginatedNotes,
+    router,
+    showCabinetLockedAlert,
+    showItemLockedAlert,
+  ]);
 
   if (!authChecked) {
     return (

--- a/src/app/notes/tags/page.tsx
+++ b/src/app/notes/tags/page.tsx
@@ -1,0 +1,468 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { onAuthStateChanged, type User } from "firebase/auth";
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  query,
+  serverTimestamp,
+  setDoc,
+  where,
+  writeBatch,
+} from "firebase/firestore";
+
+import NoteTagQuickEditor from "@/components/NoteTagQuickEditor";
+import { getFirebaseAuth, getFirebaseDb } from "@/lib/firebase";
+import { NOTE_TAG_LIMIT, normalizeNoteTags } from "@/lib/note";
+import { buttonClass } from "@/lib/ui";
+
+function formatTotal(count: number): string {
+  return count.toLocaleString("zh-TW");
+}
+
+export default function NoteTagManagerPage() {
+  const [user, setUser] = useState<User | null>(null);
+  const [authChecked, setAuthChecked] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [tags, setTags] = useState<string[]>([]);
+  const [filter, setFilter] = useState("");
+  const [tagInput, setTagInput] = useState("");
+  const [tagError, setTagError] = useState<string | null>(null);
+  const [tagMessage, setTagMessage] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [editingTag, setEditingTag] = useState<string | null>(null);
+  const [editingValue, setEditingValue] = useState("");
+  const [quickEditorOpen, setQuickEditorOpen] = useState(false);
+
+  useEffect(() => {
+    const auth = getFirebaseAuth();
+    if (!auth) {
+      setAuthChecked(true);
+      setLoading(false);
+      return undefined;
+    }
+    const unsub = onAuthStateChanged(auth, (current) => {
+      setUser(current);
+      setAuthChecked(true);
+    });
+    return () => unsub();
+  }, []);
+
+  useEffect(() => {
+    if (!user) {
+      setTags([]);
+      setLoading(false);
+      return;
+    }
+    const db = getFirebaseDb();
+    if (!db) {
+      setTags([]);
+      setLoading(false);
+      setTagError("Firebase 尚未設定");
+      return;
+    }
+    setLoading(true);
+    setTagError(null);
+    getDoc(doc(db, "user", user.uid))
+      .then((snap) => {
+        if (!snap.exists()) {
+          setTags([]);
+          return;
+        }
+        const data = snap.data();
+        setTags(normalizeNoteTags(data?.noteTags));
+      })
+      .catch((err) => {
+        console.error("載入筆記標籤時發生錯誤", err);
+        setTags([]);
+        setTagError("載入標籤時發生錯誤");
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [user]);
+
+  const filteredTags = useMemo(() => {
+    const keyword = filter.trim().toLowerCase();
+    if (!keyword) {
+      return tags;
+    }
+    return tags.filter((tag) => tag.toLowerCase().includes(keyword));
+  }, [filter, tags]);
+
+  async function persistTags(nextTags: string[]) {
+    if (!user) {
+      throw new Error("請先登入");
+    }
+    const db = getFirebaseDb();
+    if (!db) {
+      throw new Error("Firebase 尚未設定");
+    }
+    await setDoc(
+      doc(db, "user", user.uid),
+      {
+        noteTags: nextTags,
+        updatedAt: serverTimestamp(),
+      },
+      { merge: true }
+    );
+  }
+
+  async function syncNotesAfterRename(target: string, nextValue: string) {
+    if (!user) {
+      return;
+    }
+    const db = getFirebaseDb();
+    if (!db) {
+      throw new Error("Firebase 尚未設定");
+    }
+    const noteQuery = query(
+      collection(db, "note"),
+      where("uid", "==", user.uid),
+      where("tags", "array-contains", target)
+    );
+    const snapshot = await getDocs(noteQuery);
+    if (snapshot.empty) {
+      return;
+    }
+    const batch = writeBatch(db);
+    snapshot.docs.forEach((docSnap) => {
+      const data = docSnap.data();
+      const rawTags = Array.isArray(data?.tags) ? data.tags : [];
+      const normalized = normalizeNoteTags(
+        rawTags.map((tag) => (tag === target ? nextValue : tag))
+      );
+      batch.update(doc(db, "note", docSnap.id), {
+        tags: normalized,
+        updatedAt: serverTimestamp(),
+      });
+    });
+    await batch.commit();
+  }
+
+  async function syncNotesAfterDelete(target: string) {
+    if (!user) {
+      return;
+    }
+    const db = getFirebaseDb();
+    if (!db) {
+      throw new Error("Firebase 尚未設定");
+    }
+    const noteQuery = query(
+      collection(db, "note"),
+      where("uid", "==", user.uid),
+      where("tags", "array-contains", target)
+    );
+    const snapshot = await getDocs(noteQuery);
+    if (snapshot.empty) {
+      return;
+    }
+    const batch = writeBatch(db);
+    snapshot.docs.forEach((docSnap) => {
+      const data = docSnap.data();
+      const rawTags = Array.isArray(data?.tags) ? data.tags : [];
+      const normalized = normalizeNoteTags(
+        rawTags.filter((tag) => tag !== target)
+      );
+      batch.update(doc(db, "note", docSnap.id), {
+        tags: normalized,
+        updatedAt: serverTimestamp(),
+      });
+    });
+    await batch.commit();
+  }
+
+  async function handleAddTag() {
+    const value = tagInput.trim();
+    if (!value) {
+      setTagError("標籤不可為空");
+      setTagMessage(null);
+      return;
+    }
+    if (tags.includes(value)) {
+      setTagError("已有相同標籤");
+      setTagMessage(null);
+      return;
+    }
+    if (tags.length >= NOTE_TAG_LIMIT) {
+      setTagError(`最多僅能維護 ${NOTE_TAG_LIMIT} 個筆記標籤`);
+      setTagMessage(null);
+      return;
+    }
+    setSaving(true);
+    setTagError(null);
+    setTagMessage(null);
+    try {
+      const nextTags = normalizeNoteTags([...tags, value]);
+      await persistTags(nextTags);
+      setTags(nextTags);
+      setTagInput("");
+      setTagMessage(`已新增 #${value}`);
+    } catch (err) {
+      console.error("新增筆記標籤時發生錯誤", err);
+      setTagError("新增標籤時發生錯誤");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleRename(tag: string) {
+    const nextValue = editingValue.trim();
+    if (!nextValue) {
+      setTagError("標籤不可為空");
+      setTagMessage(null);
+      return;
+    }
+    if (nextValue !== tag && tags.includes(nextValue)) {
+      setTagError("已有相同標籤");
+      setTagMessage(null);
+      return;
+    }
+    setSaving(true);
+    setTagError(null);
+    setTagMessage(null);
+    try {
+      const nextTags = normalizeNoteTags([
+        ...tags.filter((item) => item !== tag),
+        nextValue,
+      ]);
+      await persistTags(nextTags);
+      await syncNotesAfterRename(tag, nextValue);
+      setTags(nextTags);
+      setEditingTag(null);
+      setEditingValue("");
+      setTagMessage(`已將 #${tag} 更名為 #${nextValue}`);
+    } catch (err) {
+      console.error("重新命名筆記標籤時發生錯誤", err);
+      setTagError("重新命名標籤時發生錯誤");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete(tag: string) {
+    const confirmed = typeof window !== "undefined"
+      ? window.confirm(`確定要刪除 #${tag} 嗎？`)
+      : false;
+    if (!confirmed) {
+      return;
+    }
+    setSaving(true);
+    setTagError(null);
+    setTagMessage(null);
+    try {
+      const nextTags = tags.filter((item) => item !== tag);
+      await persistTags(nextTags);
+      await syncNotesAfterDelete(tag);
+      setTags(nextTags);
+      setTagMessage(`已刪除 #${tag}`);
+    } catch (err) {
+      console.error("刪除筆記標籤時發生錯誤", err);
+      setTagError("刪除標籤時發生錯誤");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!authChecked) {
+    return (
+      <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+        <div className="mx-auto w-full max-w-3xl rounded-2xl border bg-white/70 p-6 text-base shadow-sm">
+          正在確認登入狀態…
+        </div>
+      </main>
+    );
+  }
+
+  if (!user) {
+    return (
+      <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 rounded-2xl border bg-white/70 p-6 shadow-sm">
+          <h1 className="text-2xl font-semibold text-gray-900">筆記標籤管理</h1>
+          <p className="text-base text-gray-600">
+            未登入。請前往
+            <Link href="/login" className="ml-1 underline">
+              /login
+            </Link>
+            以管理筆記標籤。
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-6">
+        <header className="space-y-2">
+          <Link href="/notes" className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700">
+            ← 返回筆記本
+          </Link>
+          <h1 className="text-2xl font-semibold text-gray-900">筆記標籤管理</h1>
+          <p className="text-sm text-gray-500">
+            建立、重新命名或刪除筆記共用標籤，並同步更新所有相關筆記。
+          </p>
+        </header>
+        <section className="space-y-4 rounded-2xl border bg-white/70 p-6 shadow-sm">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <label className="flex flex-1 flex-col space-y-2">
+              <span className="text-sm font-medium text-gray-700">新增標籤</span>
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                <input
+                  value={tagInput}
+                  onChange={(event) => {
+                    setTagInput(event.target.value);
+                    setTagError(null);
+                    setTagMessage(null);
+                  }}
+                  placeholder="輸入標籤名稱"
+                  className="h-11 flex-1 rounded-xl border px-4 text-base"
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      event.preventDefault();
+                      void handleAddTag();
+                    }
+                  }}
+                />
+                <button
+                  type="button"
+                  onClick={() => void handleAddTag()}
+                  className={`${buttonClass({ variant: "primary", size: "sm" })} w-full sm:w-auto`}
+                  disabled={saving}
+                >
+                  新增
+                </button>
+              </div>
+            </label>
+            <label className="flex flex-col space-y-1">
+              <span className="text-sm font-medium text-gray-700">搜尋標籤</span>
+              <input
+                value={filter}
+                onChange={(event) => setFilter(event.target.value)}
+                placeholder="輸入關鍵字過濾"
+                className="h-11 w-full rounded-xl border px-4 text-base"
+              />
+            </label>
+          </div>
+          <div className="flex flex-wrap items-center gap-3 text-xs text-gray-500">
+            <span>目前共有 {formatTotal(tags.length)} 個標籤。</span>
+            <button
+              type="button"
+              onClick={() => setQuickEditorOpen(true)}
+              className={buttonClass({ variant: "secondary", size: "sm" })}
+            >
+              使用快速編輯器
+            </button>
+          </div>
+          {tagError ? (
+            <div className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{tagError}</div>
+          ) : null}
+          {tagMessage ? (
+            <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">{tagMessage}</div>
+          ) : null}
+          <div className="rounded-2xl border border-gray-200">
+            {loading ? (
+              <div className="p-6 text-center text-sm text-gray-500">載入標籤中…</div>
+            ) : filteredTags.length === 0 ? (
+              <div className="p-6 text-center text-sm text-gray-500">沒有符合條件的標籤。</div>
+            ) : (
+              <ul className="divide-y text-sm text-gray-700">
+                {filteredTags.map((tag) => (
+                  <li key={tag} className="flex flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+                    {editingTag === tag ? (
+                      <div className="flex flex-1 flex-col gap-2 sm:flex-row sm:items-center">
+                        <input
+                          value={editingValue}
+                          onChange={(event) => setEditingValue(event.target.value)}
+                          className="h-10 flex-1 rounded-lg border px-3 text-sm"
+                          placeholder="輸入新標籤名稱"
+                        />
+                        <div className="flex items-center gap-2">
+                          <button
+                            type="button"
+                            onClick={() => void handleRename(tag)}
+                            className={buttonClass({ variant: "primary", size: "sm" })}
+                            disabled={saving}
+                          >
+                            儲存
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setEditingTag(null);
+                              setEditingValue("");
+                              setTagError(null);
+                              setTagMessage(null);
+                            }}
+                            className={buttonClass({ variant: "secondary", size: "sm" })}
+                            disabled={saving}
+                          >
+                            取消
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="flex flex-1 flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                        <span className="break-anywhere text-base font-medium text-gray-900">#{tag}</span>
+                        <div className="flex items-center gap-2">
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setEditingTag(tag);
+                              setEditingValue(tag);
+                              setTagError(null);
+                              setTagMessage(null);
+                            }}
+                            className={buttonClass({ variant: "secondary", size: "sm" })}
+                            disabled={saving}
+                          >
+                            重新命名
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => void handleDelete(tag)}
+                            className={buttonClass({ variant: "outlineDanger", size: "sm" })}
+                            disabled={saving}
+                          >
+                            刪除
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </section>
+      </div>
+      <NoteTagQuickEditor
+        open={quickEditorOpen}
+        onClose={() => setQuickEditorOpen(false)}
+        userId={user.uid}
+        tags={tags}
+        onTagsChange={(nextTags) => {
+          setTags(nextTags);
+          setTagMessage("已更新標籤列表");
+          setTagError(null);
+        }}
+        onTagRenamed={(previousTag, nextTag) => {
+          setTags((prev) =>
+            prev.map((tag) => (tag === previousTag ? nextTag : tag))
+          );
+        }}
+        onTagDeleted={(target) => {
+          setTags((prev) => prev.filter((tag) => tag !== target));
+        }}
+        onStatus={(status) => {
+          setTagMessage(status.message ?? null);
+          setTagError(status.error ?? null);
+        }}
+      />
+    </main>
+  );
+}

--- a/src/app/notes/tags/page.tsx
+++ b/src/app/notes/tags/page.tsx
@@ -17,7 +17,7 @@ import {
 
 import NoteTagQuickEditor from "@/components/NoteTagQuickEditor";
 import { getFirebaseAuth, getFirebaseDb } from "@/lib/firebase";
-import { NOTE_TAG_LIMIT, normalizeNoteTags } from "@/lib/note";
+import { normalizeNoteTags } from "@/lib/note";
 import { buttonClass } from "@/lib/ui";
 
 function formatTotal(count: number): string {
@@ -185,11 +185,6 @@ export default function NoteTagManagerPage() {
     }
     if (tags.includes(value)) {
       setTagError("已有相同標籤");
-      setTagMessage(null);
-      return;
-    }
-    if (tags.length >= NOTE_TAG_LIMIT) {
-      setTagError(`最多僅能維護 ${NOTE_TAG_LIMIT} 個筆記標籤`);
       setTagMessage(null);
       return;
     }

--- a/src/components/ItemForm.tsx
+++ b/src/components/ItemForm.tsx
@@ -69,7 +69,14 @@ import {
   type InsightEntry,
 } from "@/lib/insights";
 
-type LinkState = { label: string; url: string; isPrimary: boolean };
+type LinkState = {
+  label: string;
+  url: string;
+  isPrimary: boolean;
+  title: string;
+  description: string;
+  siteName: string;
+};
 
 type AppearanceState = {
   id: string;
@@ -476,11 +483,21 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
                     label?: unknown;
                     url?: unknown;
                     isPrimary?: unknown;
+                    title?: unknown;
+                    description?: unknown;
+                    siteName?: unknown;
                   };
                   return {
                     label: typeof record?.label === "string" ? record.label : "",
                     url: typeof record?.url === "string" ? record.url : "",
                     isPrimary: Boolean(record?.isPrimary),
+                    title: typeof record?.title === "string" ? record.title : "",
+                    description:
+                      typeof record?.description === "string"
+                        ? record.description
+                        : "",
+                    siteName:
+                      typeof record?.siteName === "string" ? record.siteName : "",
                   };
                 })
               )
@@ -732,6 +749,9 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
       label: link.label.trim(),
       url: link.url.trim(),
       isPrimary: link.isPrimary,
+      title: link.title.trim() || null,
+      description: link.description.trim() || null,
+      siteName: link.siteName.trim() || null,
     }));
 
     const hasHalfFilled = normalizedLinks.some(
@@ -934,6 +954,9 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
             label: link.label,
             url: link.url,
             isPrimary: Boolean(link.isPrimary),
+            title: link.title ?? "",
+            description: link.description ?? "",
+            siteName: link.siteName ?? "",
           }))
         )
       );
@@ -1599,7 +1622,14 @@ export default function ItemForm({ itemId, initialCabinetId }: ItemFormProps) {
                     setLinks((prev) =>
                       normalizePrimaryLinks([
                         ...prev,
-                        { label: "", url: "", isPrimary: prev.length === 0 },
+                        {
+                          label: "",
+                          url: "",
+                          isPrimary: prev.length === 0,
+                          title: "",
+                          description: "",
+                          siteName: "",
+                        },
                       ])
                     );
                   }}

--- a/src/components/LinkTargetSelector.tsx
+++ b/src/components/LinkTargetSelector.tsx
@@ -1,0 +1,576 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  onSnapshot,
+  query,
+  where,
+} from "firebase/firestore";
+
+import { getFirebaseDb } from "@/lib/firebase";
+
+const UNCATEGORIZED_KEY = "__uncategorized__";
+
+export type LinkTargetSelectorProps = {
+  userId: string | null;
+  selectedCabinetIds: string[];
+  onCabinetIdsChange: (ids: string[]) => void;
+  selectedItemIds: string[];
+  onItemIdsChange: (ids: string[]) => void;
+  onError?: (message: string) => void;
+};
+
+type CabinetOption = {
+  id: string;
+  name: string;
+};
+
+type ItemOption = {
+  id: string;
+  title: string;
+  cabinetId: string | null;
+};
+
+type ItemCache = Record<string, ItemOption[]>;
+
+type ItemLookup = Record<string, ItemOption>;
+
+type StatusMessage = {
+  type: "idle" | "loading" | "error";
+  message: string | null;
+};
+
+function normalizeCabinetName(value: unknown): string {
+  const raw = typeof value === "string" ? value.trim() : "";
+  return raw || "未命名櫃子";
+}
+
+function normalizeItemTitle(value: unknown): string {
+  const raw = typeof value === "string" ? value.trim() : "";
+  return raw || "未命名作品";
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return Array.from(new Set(values)).sort();
+}
+
+export default function LinkTargetSelector({
+  userId,
+  selectedCabinetIds,
+  onCabinetIdsChange,
+  selectedItemIds,
+  onItemIdsChange,
+  onError,
+}: LinkTargetSelectorProps) {
+  const [open, setOpen] = useState(false);
+  const [cabinetSearch, setCabinetSearch] = useState("");
+  const [cabinetOptions, setCabinetOptions] = useState<CabinetOption[]>([]);
+  const [cabinetStatus, setCabinetStatus] = useState<StatusMessage>({
+    type: "idle",
+    message: null,
+  });
+  const [activeCabinetForItems, setActiveCabinetForItems] = useState<string | null>(
+    null
+  );
+  const [itemSearch, setItemSearch] = useState("");
+  const [itemStatus, setItemStatus] = useState<StatusMessage>({
+    type: "idle",
+    message: null,
+  });
+  const [itemCache, setItemCache] = useState<ItemCache>({});
+  const [itemLookup, setItemLookup] = useState<ItemLookup>({});
+
+  const cabinetMap = useMemo(() => {
+    const entries = cabinetOptions.map((option) => [option.id, option] as const);
+    return new Map(entries);
+  }, [cabinetOptions]);
+
+  useEffect(() => {
+    setCabinetSearch("");
+    setItemSearch("");
+    setActiveCabinetForItems(null);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setOpen(false);
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    if (!userId) {
+      setCabinetOptions([]);
+      setCabinetStatus({
+        type: "error",
+        message: "請先登入後再選擇連結目標",
+      });
+      return;
+    }
+    const db = getFirebaseDb();
+    if (!db) {
+      setCabinetOptions([]);
+      setCabinetStatus({
+        type: "error",
+        message: "Firebase 尚未設定",
+      });
+      return;
+    }
+    setCabinetStatus({ type: "loading", message: null });
+    const cabinetQuery = query(
+      collection(db, "cabinet"),
+      where("uid", "==", userId)
+    );
+    const unsubscribe = onSnapshot(
+      cabinetQuery,
+      (snapshot) => {
+        const next = snapshot.docs
+          .map((docSnap) => ({
+            id: docSnap.id,
+            name: normalizeCabinetName(docSnap.data()?.name),
+          }))
+          .sort((a, b) => a.name.localeCompare(b.name, "zh-Hant"));
+        setCabinetOptions(next);
+        setCabinetStatus({ type: "idle", message: null });
+      },
+      (error) => {
+        console.error("載入櫃子清單時發生錯誤", error);
+        const message = "載入櫃子清單時發生錯誤";
+        setCabinetStatus({ type: "error", message });
+        onError?.(message);
+      }
+    );
+    return () => unsubscribe();
+  }, [onError, open, userId]);
+
+  useEffect(() => {
+    if (cabinetOptions.length === 0) {
+      return;
+    }
+    const filteredIds = selectedCabinetIds.filter((id) => cabinetMap.has(id));
+    if (filteredIds.length !== selectedCabinetIds.length) {
+      onCabinetIdsChange(filteredIds);
+    }
+  }, [cabinetMap, cabinetOptions.length, onCabinetIdsChange, selectedCabinetIds]);
+
+  const visibleCabinets = useMemo(() => {
+    const keyword = cabinetSearch.trim().toLowerCase();
+    if (!keyword) {
+      return cabinetOptions;
+    }
+    return cabinetOptions.filter((option) =>
+      option.name.toLowerCase().includes(keyword)
+    );
+  }, [cabinetOptions, cabinetSearch]);
+
+  const activeCabinetLabel = useMemo(() => {
+    if (!activeCabinetForItems) {
+      return "";
+    }
+    if (activeCabinetForItems === UNCATEGORIZED_KEY) {
+      return "未分類作品";
+    }
+    return cabinetMap.get(activeCabinetForItems)?.name ?? "";
+  }, [activeCabinetForItems, cabinetMap]);
+
+  const selectedCabinets = useMemo(() => {
+    return selectedCabinetIds
+      .map((id) => cabinetMap.get(id))
+      .filter((option): option is CabinetOption => Boolean(option));
+  }, [cabinetMap, selectedCabinetIds]);
+
+  const selectedItems = useMemo(() => {
+    return selectedItemIds
+      .map((id) => itemLookup[id])
+      .filter((option): option is ItemOption => Boolean(option));
+  }, [itemLookup, selectedItemIds]);
+
+  const filteredItemsForActiveCabinet = useMemo(() => {
+    if (!activeCabinetForItems) {
+      return [] as ItemOption[];
+    }
+    const bucketKey = activeCabinetForItems;
+    const base = itemCache[bucketKey] ?? [];
+    const keyword = itemSearch.trim().toLowerCase();
+    if (!keyword) {
+      return base;
+    }
+    return base.filter((option) =>
+      option.title.toLowerCase().includes(keyword)
+    );
+  }, [activeCabinetForItems, itemCache, itemSearch]);
+
+  const ensureItemLookup = useCallback(
+    async (itemId: string) => {
+      if (!userId) {
+        return;
+      }
+      if (itemLookup[itemId]) {
+        return;
+      }
+      const db = getFirebaseDb();
+      if (!db) {
+        return;
+      }
+      try {
+        const snap = await getDoc(doc(db, "item", itemId));
+        if (!snap.exists()) {
+          onItemIdsChange(selectedItemIds.filter((id) => id !== itemId));
+          return;
+        }
+        const data = snap.data();
+        if (data?.uid !== userId) {
+          onItemIdsChange(selectedItemIds.filter((id) => id !== itemId));
+          return;
+        }
+        const option: ItemOption = {
+          id: snap.id,
+          title: normalizeItemTitle(data?.titleZh),
+          cabinetId:
+            typeof data?.cabinetId === "string" && data.cabinetId.trim().length > 0
+              ? data.cabinetId
+              : null,
+        };
+        setItemLookup((prev) => ({ ...prev, [option.id]: option }));
+        const cacheKey = option.cabinetId ?? UNCATEGORIZED_KEY;
+        setItemCache((prev) => {
+          const existing = prev[cacheKey] ?? [];
+          if (existing.some((item) => item.id === option.id)) {
+            return prev;
+          }
+          const next = [...existing, option].sort((a, b) =>
+            a.title.localeCompare(b.title, "zh-Hant")
+          );
+          return { ...prev, [cacheKey]: next };
+        });
+      } catch (error) {
+        console.error("載入作品資訊時發生錯誤", error);
+      }
+    },
+    [onItemIdsChange, selectedItemIds, itemLookup, userId]
+  );
+
+  useEffect(() => {
+    selectedItemIds.forEach((id) => {
+      void ensureItemLookup(id);
+    });
+  }, [ensureItemLookup, selectedItemIds]);
+
+  const loadItemsForCabinet = useCallback(
+    async (cabinetId: string) => {
+      if (!userId) {
+        setItemStatus({
+          type: "error",
+          message: "請先登入後再載入作品",
+        });
+        return;
+      }
+      if (itemCache[cabinetId]) {
+        setItemStatus({ type: "idle", message: null });
+        return;
+      }
+      const db = getFirebaseDb();
+      if (!db) {
+        setItemStatus({
+          type: "error",
+          message: "Firebase 尚未設定",
+        });
+        return;
+      }
+      setItemStatus({ type: "loading", message: null });
+      try {
+        const constraints = [where("uid", "==", userId)];
+        if (cabinetId === UNCATEGORIZED_KEY) {
+          constraints.push(where("cabinetId", "==", null));
+        } else {
+          constraints.push(where("cabinetId", "==", cabinetId));
+        }
+        const itemQuery = query(collection(db, "item"), ...constraints);
+        const snapshot = await getDocs(itemQuery);
+        const items = snapshot.docs
+          .map((docSnap) => {
+            const data = docSnap.data();
+            return {
+              id: docSnap.id,
+              title: normalizeItemTitle(data?.titleZh),
+              cabinetId:
+                typeof data?.cabinetId === "string" &&
+                data.cabinetId.trim().length > 0
+                  ? data.cabinetId
+                  : null,
+            } satisfies ItemOption;
+          })
+          .sort((a, b) => a.title.localeCompare(b.title, "zh-Hant"));
+        setItemCache((prev) => ({ ...prev, [cabinetId]: items }));
+        setItemLookup((prev) => {
+          if (items.length === 0) {
+            return prev;
+          }
+          const next: ItemLookup = { ...prev };
+          items.forEach((item) => {
+            next[item.id] = item;
+          });
+          return next;
+        });
+        setItemStatus({ type: "idle", message: null });
+      } catch (error) {
+        console.error("載入作品清單時發生錯誤", error);
+        const message = "載入作品清單時發生錯誤";
+        setItemStatus({ type: "error", message });
+        onError?.(message);
+      }
+    },
+    [itemCache, onError, userId]
+  );
+
+  useEffect(() => {
+    if (!activeCabinetForItems) {
+      return;
+    }
+    void loadItemsForCabinet(activeCabinetForItems);
+  }, [activeCabinetForItems, loadItemsForCabinet]);
+
+  const combinedCabinetOptions = useMemo(() => {
+    const base = cabinetOptions;
+    return base;
+  }, [cabinetOptions]);
+
+  function toggleCabinet(id: string) {
+    const next = selectedCabinetIds.includes(id)
+      ? selectedCabinetIds.filter((value) => value !== id)
+      : [...selectedCabinetIds, id];
+    onCabinetIdsChange(uniqueSorted(next));
+  }
+
+  function toggleItem(id: string) {
+    const next = selectedItemIds.includes(id)
+      ? selectedItemIds.filter((value) => value !== id)
+      : [...selectedItemIds, id];
+    onItemIdsChange(uniqueSorted(next));
+  }
+
+  function removeCabinet(id: string) {
+    onCabinetIdsChange(selectedCabinetIds.filter((value) => value !== id));
+  }
+
+  function removeItem(id: string) {
+    onItemIdsChange(selectedItemIds.filter((value) => value !== id));
+  }
+
+  const hasSelections = selectedCabinetIds.length > 0 || selectedItemIds.length > 0;
+
+  return (
+    <section className="space-y-4 rounded-xl border border-gray-200 bg-white/50 p-4">
+      <header className="space-y-1">
+        <h2 className="text-sm font-medium text-gray-700">連結目標</h2>
+        <p className="text-xs text-gray-500">
+          選擇此筆記要關聯的櫃子或作品，採分步載入避免一次讀取所有作品。
+        </p>
+      </header>
+      <div className="space-y-3">
+        {hasSelections ? (
+          <div className="space-y-2 text-sm">
+            {selectedCabinets.length > 0 ? (
+              <div className="space-y-1">
+                <span className="text-xs font-medium text-gray-500">櫃子</span>
+                <div className="flex flex-wrap gap-2">
+                  {selectedCabinets.map((cabinet) => (
+                    <button
+                      key={cabinet.id}
+                      type="button"
+                      onClick={() => removeCabinet(cabinet.id)}
+                      className="group inline-flex items-center gap-1 rounded-full bg-indigo-50 px-3 py-1 text-xs text-indigo-600 transition hover:bg-indigo-100"
+                    >
+                      <span>{cabinet.name}</span>
+                      <span className="text-[10px] text-indigo-400 group-hover:text-indigo-600">移除</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+            {selectedItems.length > 0 ? (
+              <div className="space-y-1">
+                <span className="text-xs font-medium text-gray-500">作品</span>
+                <div className="flex flex-wrap gap-2">
+                  {selectedItems.map((item) => {
+                    const cabinetLabel = item.cabinetId
+                      ? cabinetMap.get(item.cabinetId)?.name ?? ""
+                      : "未分類";
+                    return (
+                      <button
+                        key={item.id}
+                        type="button"
+                        onClick={() => removeItem(item.id)}
+                        className="group inline-flex items-center gap-1 rounded-full bg-sky-100 px-3 py-1 text-xs text-sky-600 transition hover:bg-sky-200"
+                      >
+                        <span>{item.title}</span>
+                        <span className="text-[10px] text-sky-400 group-hover:text-sky-600">{cabinetLabel}</span>
+                        <span className="text-[10px] text-sky-400 group-hover:text-sky-600">移除</span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            ) : null}
+          </div>
+        ) : (
+          <p className="text-sm text-gray-500">尚未選取任何連結目標。</p>
+        )}
+        <div>
+          <button
+            type="button"
+            onClick={() => setOpen(true)}
+            className="inline-flex items-center rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm transition hover:border-gray-400 hover:bg-gray-50"
+          >
+            編輯連結目標
+          </button>
+        </div>
+      </div>
+      {open ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/50 p-4">
+          <div className="flex w-full max-w-5xl flex-col gap-4 rounded-2xl bg-white p-6 shadow-xl">
+            <header className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900">選擇連結目標</h3>
+                <p className="text-sm text-gray-500">
+                  先挑選要連結的櫃子，再指定該櫃底下的作品，避免一次載入所有作品資料。
+                </p>
+              </div>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => setOpen(false)}
+                  className="inline-flex items-center rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm transition hover:border-gray-400 hover:bg-gray-50"
+                >
+                  關閉
+                </button>
+              </div>
+            </header>
+            <div className="grid gap-6 lg:grid-cols-2">
+              <div className="space-y-3">
+                <div className="flex flex-col gap-2">
+                  <span className="text-sm font-medium text-gray-700">櫃子</span>
+                  <input
+                    value={cabinetSearch}
+                    onChange={(event) => setCabinetSearch(event.target.value)}
+                    placeholder="搜尋櫃子"
+                    className="h-10 w-full rounded-lg border border-gray-200 px-3 text-sm"
+                  />
+                </div>
+                <div className="max-h-72 space-y-1 overflow-auto rounded-xl border border-gray-200 bg-white/80 p-2 text-sm">
+                  {cabinetStatus.type === "loading" ? (
+                    <p className="px-2 py-1 text-xs text-gray-500">載入中…</p>
+                  ) : visibleCabinets.length > 0 ? (
+                    visibleCabinets.map((option) => (
+                      <label
+                        key={option.id}
+                        className="flex items-center gap-2 rounded-lg px-2 py-1 transition hover:bg-gray-100"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={selectedCabinetIds.includes(option.id)}
+                          onChange={() => toggleCabinet(option.id)}
+                          className="h-4 w-4 rounded border-gray-300 text-indigo-500 focus:ring-indigo-400"
+                        />
+                        <span className="flex-1 break-anywhere">{option.name}</span>
+                      </label>
+                    ))
+                  ) : (
+                    <p className="px-2 py-1 text-xs text-gray-500">
+                      {cabinetStatus.type === "error"
+                        ? cabinetStatus.message
+                        : "尚無櫃子或無符合條件的結果。"}
+                    </p>
+                  )}
+                </div>
+              </div>
+              <div className="space-y-3">
+                <div className="flex flex-col gap-2">
+                  <label className="text-sm font-medium text-gray-700">
+                    指定作品（請先選擇櫃子）
+                  </label>
+                  <select
+                    value={activeCabinetForItems ?? ""}
+                    onChange={(event) => {
+                      const value = event.target.value;
+                      setItemSearch("");
+                      setActiveCabinetForItems(value ? value : null);
+                    }}
+                    className="h-10 w-full rounded-lg border border-gray-200 bg-white px-3 text-sm"
+                  >
+                    <option value="">選擇要瀏覽的櫃子</option>
+                    {combinedCabinetOptions.map((option) => (
+                      <option key={option.id} value={option.id}>
+                        {option.name}
+                      </option>
+                    ))}
+                    <option value={UNCATEGORIZED_KEY}>未分類作品</option>
+                  </select>
+                </div>
+                {activeCabinetForItems ? (
+                  <div className="space-y-2">
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                      <span className="text-sm font-medium text-gray-700">
+                        {activeCabinetLabel || "作品清單"}
+                      </span>
+                      <input
+                        value={itemSearch}
+                        onChange={(event) => setItemSearch(event.target.value)}
+                        placeholder="搜尋作品名稱"
+                        className="h-10 w-full max-w-xs rounded-lg border border-gray-200 px-3 text-sm"
+                      />
+                    </div>
+                    <div className="max-h-72 space-y-1 overflow-auto rounded-xl border border-gray-200 bg-white/80 p-2 text-sm">
+                      {itemStatus.type === "loading" && !itemCache[activeCabinetForItems] ? (
+                        <p className="px-2 py-1 text-xs text-gray-500">載入中…</p>
+                      ) : filteredItemsForActiveCabinet.length > 0 ? (
+                        filteredItemsForActiveCabinet.map((option) => (
+                          <label
+                            key={option.id}
+                            className="flex items-center gap-2 rounded-lg px-2 py-1 transition hover:bg-gray-100"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={selectedItemIds.includes(option.id)}
+                              onChange={() => toggleItem(option.id)}
+                              className="h-4 w-4 rounded border-gray-300 text-sky-500 focus:ring-sky-400"
+                            />
+                            <span className="flex-1 break-anywhere">{option.title}</span>
+                          </label>
+                        ))
+                      ) : (
+                        <p className="px-2 py-1 text-xs text-gray-500">
+                          {itemStatus.type === "error"
+                            ? itemStatus.message
+                            : "尚無作品或無符合條件的結果。"}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                ) : (
+                  <p className="text-xs text-gray-500">
+                    請先選擇要瀏覽的櫃子，再載入該櫃底下的作品。
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/components/NoteTagQuickEditor.tsx
+++ b/src/components/NoteTagQuickEditor.tsx
@@ -13,7 +13,7 @@ import {
 } from "firebase/firestore";
 
 import { getFirebaseDb } from "@/lib/firebase";
-import { NOTE_TAG_LIMIT, normalizeNoteTags } from "@/lib/note";
+import { normalizeNoteTags } from "@/lib/note";
 
 const inputClass =
   "h-10 w-full rounded-lg border border-gray-200 bg-white px-3 text-sm text-gray-900 shadow-sm focus:border-gray-300 focus:outline-none";
@@ -197,13 +197,6 @@ export default function NoteTagQuickEditor({
       setMessage(messageText);
       onStatus?.({ message: messageText, error: null });
       setTagInput("");
-      return;
-    }
-    if (localTags.length >= NOTE_TAG_LIMIT) {
-      const errorMessage = `最多僅能維護 ${NOTE_TAG_LIMIT} 個筆記標籤`;
-      setError(errorMessage);
-      setMessage(null);
-      onStatus?.({ message: null, error: errorMessage });
       return;
     }
     if (!userId) {

--- a/src/components/NoteTagQuickEditor.tsx
+++ b/src/components/NoteTagQuickEditor.tsx
@@ -1,0 +1,427 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  collection,
+  doc,
+  getDocs,
+  query,
+  serverTimestamp,
+  setDoc,
+  where,
+  writeBatch,
+} from "firebase/firestore";
+
+import { getFirebaseDb } from "@/lib/firebase";
+import { normalizeNoteTags } from "@/lib/note";
+
+const inputClass =
+  "h-10 w-full rounded-lg border border-gray-200 bg-white px-3 text-sm text-gray-900 shadow-sm focus:border-gray-300 focus:outline-none";
+
+const actionButtonClass =
+  "inline-flex items-center justify-center rounded-lg border px-3 py-2 text-sm transition";
+
+type StatusState = { message?: string | null; error?: string | null };
+
+type NoteTagQuickEditorProps = {
+  open: boolean;
+  onClose: () => void;
+  userId: string;
+  tags: string[];
+  onTagsChange: (tags: string[]) => void;
+  onTagRenamed?: (previousTag: string, nextTag: string) => void;
+  onTagDeleted?: (tag: string) => void;
+  onStatus?: (status: StatusState) => void;
+};
+
+export default function NoteTagQuickEditor({
+  open,
+  onClose,
+  userId,
+  tags,
+  onTagsChange,
+  onTagRenamed,
+  onTagDeleted,
+  onStatus,
+}: NoteTagQuickEditorProps) {
+  const [localTags, setLocalTags] = useState<string[]>(tags);
+  const [tagInput, setTagInput] = useState("");
+  const [filter, setFilter] = useState("");
+  const [editingTag, setEditingTag] = useState<string | null>(null);
+  const [editingValue, setEditingValue] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    setLocalTags(tags);
+  }, [open, tags]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    setTagInput("");
+    setFilter("");
+    setEditingTag(null);
+    setEditingValue("");
+    setSaving(false);
+    setError(null);
+    setMessage(null);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose]);
+
+  const filteredTags = useMemo(() => {
+    const keyword = filter.trim().toLowerCase();
+    if (!keyword) {
+      return localTags;
+    }
+    return localTags.filter((tag) => tag.toLowerCase().includes(keyword));
+  }, [localTags, filter]);
+
+  if (!open) {
+    return null;
+  }
+
+  async function persistNoteTags(nextTags: string[]) {
+    const db = getFirebaseDb();
+    if (!db) {
+      throw new Error("Firebase 尚未設定");
+    }
+    const userRef = doc(db, "user", userId);
+    await setDoc(
+      userRef,
+      {
+        noteTags: nextTags,
+        updatedAt: serverTimestamp(),
+      },
+      { merge: true }
+    );
+  }
+
+  async function syncNotesAfterRename(target: string, nextValue: string) {
+    const db = getFirebaseDb();
+    if (!db) {
+      throw new Error("Firebase 尚未設定");
+    }
+    const noteQuery = query(
+      collection(db, "note"),
+      where("uid", "==", userId),
+      where("tags", "array-contains", target)
+    );
+    const snapshot = await getDocs(noteQuery);
+    if (snapshot.empty) {
+      return;
+    }
+    const batch = writeBatch(db);
+    snapshot.docs.forEach((docSnap) => {
+      const data = docSnap.data();
+      const rawTags = Array.isArray(data?.tags) ? data.tags : [];
+      const normalized = normalizeNoteTags(
+        rawTags.map((tag) => (tag === target ? nextValue : tag))
+      );
+      batch.update(doc(db, "note", docSnap.id), {
+        tags: normalized,
+        updatedAt: serverTimestamp(),
+      });
+    });
+    await batch.commit();
+  }
+
+  async function syncNotesAfterDelete(target: string) {
+    const db = getFirebaseDb();
+    if (!db) {
+      throw new Error("Firebase 尚未設定");
+    }
+    const noteQuery = query(
+      collection(db, "note"),
+      where("uid", "==", userId),
+      where("tags", "array-contains", target)
+    );
+    const snapshot = await getDocs(noteQuery);
+    if (snapshot.empty) {
+      return;
+    }
+    const batch = writeBatch(db);
+    snapshot.docs.forEach((docSnap) => {
+      const data = docSnap.data();
+      const rawTags = Array.isArray(data?.tags) ? data.tags : [];
+      const normalized = normalizeNoteTags(
+        rawTags.filter((tag) => tag !== target)
+      );
+      batch.update(doc(db, "note", docSnap.id), {
+        tags: normalized,
+        updatedAt: serverTimestamp(),
+      });
+    });
+    await batch.commit();
+  }
+
+  async function handleAddTag() {
+    const value = tagInput.trim();
+    if (!value) {
+      setError("請輸入標籤名稱");
+      setMessage(null);
+      return;
+    }
+    if (!userId) {
+      setError("請先登入");
+      setMessage(null);
+      return;
+    }
+    if (localTags.includes(value)) {
+      setError("已有相同標籤");
+      setMessage(null);
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    setMessage(null);
+    try {
+      const nextTags = normalizeNoteTags([...localTags, value]);
+      await persistNoteTags(nextTags);
+      setLocalTags(nextTags);
+      onTagsChange(nextTags);
+      setTagInput("");
+      const successMessage = `已新增 #${value}`;
+      setMessage(successMessage);
+      onStatus?.({ message: successMessage, error: null });
+    } catch (err) {
+      console.error("新增筆記標籤時發生錯誤", err);
+      const failureMessage = "新增標籤時發生錯誤";
+      setError(failureMessage);
+      onStatus?.({ message: null, error: failureMessage });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleRenameConfirm(target: string) {
+    if (!editingTag) {
+      return;
+    }
+    const nextValue = editingValue.trim();
+    if (!nextValue) {
+      setError("標籤不可為空");
+      setMessage(null);
+      return;
+    }
+    if (!userId) {
+      setError("請先登入");
+      setMessage(null);
+      return;
+    }
+    if (nextValue !== target && localTags.includes(nextValue)) {
+      setError("已有相同標籤");
+      setMessage(null);
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    setMessage(null);
+    try {
+      const nextTags = normalizeNoteTags([
+        ...localTags.filter((tag) => tag !== target),
+        nextValue,
+      ]);
+      await persistNoteTags(nextTags);
+      await syncNotesAfterRename(target, nextValue);
+      setLocalTags(nextTags);
+      onTagsChange(nextTags);
+      onTagRenamed?.(target, nextValue);
+      setEditingTag(null);
+      setEditingValue("");
+      const successMessage = `已將 #${target} 更名為 #${nextValue}`;
+      setMessage(successMessage);
+      onStatus?.({ message: successMessage, error: null });
+    } catch (err) {
+      console.error("重新命名筆記標籤時發生錯誤", err);
+      const failureMessage = "重新命名標籤時發生錯誤";
+      setError(failureMessage);
+      onStatus?.({ message: null, error: failureMessage });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDeleteTag(target: string) {
+    if (!userId) {
+      setError("請先登入");
+      setMessage(null);
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    setMessage(null);
+    try {
+      const nextTags = localTags.filter((tag) => tag !== target);
+      await persistNoteTags(nextTags);
+      await syncNotesAfterDelete(target);
+      setLocalTags(nextTags);
+      onTagsChange(nextTags);
+      onTagDeleted?.(target);
+      const successMessage = `已刪除 #${target}`;
+      setMessage(successMessage);
+      onStatus?.({ message: successMessage, error: null });
+    } catch (err) {
+      console.error("刪除筆記標籤時發生錯誤", err);
+      const failureMessage = "刪除標籤時發生錯誤";
+      setError(failureMessage);
+      onStatus?.({ message: null, error: failureMessage });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-6">
+      <div className="flex w-full max-w-xl flex-col gap-4 rounded-2xl bg-white p-6 shadow-xl">
+        <header className="space-y-1">
+          <h2 className="text-lg font-semibold text-gray-900">筆記標籤管理</h2>
+          <p className="text-sm text-gray-500">新增、重新命名或刪除筆記共用標籤。</p>
+        </header>
+        <div className="space-y-3">
+          <label className="space-y-1">
+            <span className="text-sm text-gray-600">搜尋既有標籤</span>
+            <input
+              value={filter}
+              onChange={(event) => setFilter(event.target.value)}
+              placeholder="輸入關鍵字"
+              className={inputClass}
+            />
+          </label>
+          <label className="space-y-1">
+            <span className="text-sm text-gray-600">新增標籤</span>
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+              <input
+                value={tagInput}
+                onChange={(event) => setTagInput(event.target.value)}
+                placeholder="輸入標籤後按新增"
+                className={inputClass}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    void handleAddTag();
+                  }
+                }}
+              />
+              <button
+                type="button"
+                onClick={() => void handleAddTag()}
+                className={`${actionButtonClass} border-gray-200 bg-gray-900 text-white hover:bg-gray-800`}
+                disabled={saving}
+              >
+                新增標籤
+              </button>
+            </div>
+          </label>
+        </div>
+        <div className="flex-1 overflow-auto rounded-xl border border-gray-200">
+          {filteredTags.length === 0 ? (
+            <div className="p-6 text-center text-sm text-gray-500">尚未建立任何標籤。</div>
+          ) : (
+            <ul className="divide-y text-sm text-gray-700">
+              {filteredTags.map((tag) => (
+                <li key={tag} className="flex items-center justify-between gap-3 px-4 py-3">
+                  {editingTag === tag ? (
+                    <div className="flex flex-1 items-center gap-2">
+                      <input
+                        value={editingValue}
+                        onChange={(event) => setEditingValue(event.target.value)}
+                        className={inputClass}
+                        placeholder="輸入新標籤名稱"
+                      />
+                      <button
+                        type="button"
+                        className={`${actionButtonClass} border-emerald-200 bg-emerald-50 text-emerald-700 hover:bg-emerald-100`}
+                        onClick={() => void handleRenameConfirm(tag)}
+                        disabled={saving}
+                      >
+                        儲存
+                      </button>
+                      <button
+                        type="button"
+                        className={`${actionButtonClass} border-gray-200 bg-white text-gray-600 hover:bg-gray-50`}
+                        onClick={() => {
+                          setEditingTag(null);
+                          setEditingValue("");
+                        }}
+                        disabled={saving}
+                      >
+                        取消
+                      </button>
+                    </div>
+                  ) : (
+                    <div className="flex flex-1 items-center justify-between gap-3">
+                      <span className="break-anywhere text-sm font-medium text-gray-800">#{tag}</span>
+                      <div className="flex items-center gap-2">
+                        <button
+                          type="button"
+                          className={`${actionButtonClass} border-gray-200 bg-white text-gray-600 hover:bg-gray-50`}
+                          onClick={() => {
+                            setEditingTag(tag);
+                            setEditingValue(tag);
+                            setError(null);
+                            setMessage(null);
+                          }}
+                          disabled={saving}
+                        >
+                          重新命名
+                        </button>
+                        <button
+                          type="button"
+                          className={`${actionButtonClass} border-red-200 bg-red-50 text-red-600 hover:bg-red-100`}
+                          onClick={() => void handleDeleteTag(tag)}
+                          disabled={saving}
+                        >
+                          刪除
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        {error ? (
+          <div className="rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+        ) : null}
+        {message ? (
+          <div className="rounded-xl bg-emerald-50 px-4 py-3 text-sm text-emerald-700">{message}</div>
+        ) : null}
+        <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            className={`${actionButtonClass} border-gray-200 bg-white text-gray-600 hover:bg-gray-50`}
+            onClick={() => {
+              setError(null);
+              setMessage(null);
+              onStatus?.({ message: null, error: null });
+              onClose();
+            }}
+            disabled={saving}
+          >
+            關閉
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,0 +1,149 @@
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function formatInlineMarkdown(raw: string): string {
+  let result = escapeHtml(raw);
+  result = result.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+  result = result.replace(/\*(.+?)\*/g, "<em>$1</em>");
+  result = result.replace(/`(.+?)`/g, "<code>$1</code>");
+  result = result.replace(/~~(.+?)~~/g, "<del>$1</del>");
+  return result;
+}
+
+export function simpleMarkdownToHtml(markdown: string): string {
+  if (!markdown.trim()) {
+    return "";
+  }
+
+  const lines = markdown.replace(/\r\n?/g, "\n").split("\n");
+  const htmlChunks: string[] = [];
+  let inList = false;
+  let inOrderedList = false;
+  let inCodeBlock = false;
+
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd();
+
+    if (line.startsWith("```")) {
+      if (inList) {
+        htmlChunks.push(inOrderedList ? "</ol>" : "</ul>");
+        inList = false;
+        inOrderedList = false;
+      }
+      if (!inCodeBlock) {
+        inCodeBlock = true;
+        htmlChunks.push("<pre><code>");
+      } else {
+        inCodeBlock = false;
+        htmlChunks.push("</code></pre>");
+      }
+      continue;
+    }
+
+    if (inCodeBlock) {
+      htmlChunks.push(`${escapeHtml(rawLine)}\n`);
+      continue;
+    }
+
+    if (!line.trim()) {
+      if (inList) {
+        htmlChunks.push(inOrderedList ? "</ol>" : "</ul>");
+        inList = false;
+        inOrderedList = false;
+      }
+      htmlChunks.push("");
+      continue;
+    }
+
+    if (line.startsWith("# ")) {
+      if (inList) {
+        htmlChunks.push(inOrderedList ? "</ol>" : "</ul>");
+        inList = false;
+        inOrderedList = false;
+      }
+      htmlChunks.push(`<h1>${formatInlineMarkdown(line.slice(2).trim())}</h1>`);
+      continue;
+    }
+    if (line.startsWith("## ")) {
+      if (inList) {
+        htmlChunks.push(inOrderedList ? "</ol>" : "</ul>");
+        inList = false;
+        inOrderedList = false;
+      }
+      htmlChunks.push(`<h2>${formatInlineMarkdown(line.slice(3).trim())}</h2>`);
+      continue;
+    }
+    if (line.startsWith("### ")) {
+      if (inList) {
+        htmlChunks.push(inOrderedList ? "</ol>" : "</ul>");
+        inList = false;
+        inOrderedList = false;
+      }
+      htmlChunks.push(`<h3>${formatInlineMarkdown(line.slice(4).trim())}</h3>`);
+      continue;
+    }
+
+    const orderedMatch = line.match(/^(\d+)\.\s+(.*)$/);
+    if (orderedMatch) {
+      if (!inList || !inOrderedList) {
+        if (inList) {
+          htmlChunks.push(inOrderedList ? "</ol>" : "</ul>");
+        }
+        htmlChunks.push("<ol>");
+        inList = true;
+        inOrderedList = true;
+      }
+      htmlChunks.push(`<li>${formatInlineMarkdown(orderedMatch[2])}</li>`);
+      continue;
+    }
+
+    if (line.startsWith("- ") || line.startsWith("* ")) {
+      if (!inList || inOrderedList) {
+        if (inList) {
+          htmlChunks.push(inOrderedList ? "</ol>" : "</ul>");
+        }
+        htmlChunks.push("<ul>");
+        inList = true;
+        inOrderedList = false;
+      }
+      htmlChunks.push(`<li>${formatInlineMarkdown(line.slice(2).trim())}</li>`);
+      continue;
+    }
+
+    if (inList) {
+      htmlChunks.push(inOrderedList ? "</ol>" : "</ul>");
+      inList = false;
+      inOrderedList = false;
+    }
+
+    htmlChunks.push(`<p>${formatInlineMarkdown(line)}</p>`);
+  }
+
+  if (inList) {
+    htmlChunks.push(inOrderedList ? "</ol>" : "</ul>");
+  }
+
+  if (inCodeBlock) {
+    htmlChunks.push("</code></pre>");
+  }
+
+  return htmlChunks.filter(Boolean).join("");
+}
+
+export function markdownPreviewHtml(markdown: string): string {
+  const html = simpleMarkdownToHtml(markdown);
+  return html || '<p class="text-sm text-gray-500">尚未輸入 Markdown 內容。</p>';
+}
+
+export function splitTags(input: string): string[] {
+  return input
+    .split(/[,\s]+/)
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}

--- a/src/lib/note.ts
+++ b/src/lib/note.ts
@@ -1,10 +1,14 @@
-export const NOTE_CATEGORY_OPTIONS = [
-  { value: "general", label: "一般筆記" },
-  { value: "progress", label: "進度心得" },
-  { value: "insight", label: "觀後感" },
-  { value: "reference", label: "資料整理" },
-] as const;
-
-export type NoteCategory = (typeof NOTE_CATEGORY_OPTIONS)[number]["value"];
-
 export const NOTE_TAG_LIMIT = 20;
+
+export function normalizeNoteTags(input: unknown): string[] {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+  return Array.from(
+    new Set(
+      input
+        .map((tag) => String(tag ?? "").trim())
+        .filter((tag): tag is string => tag.length > 0)
+    )
+  ).sort((a, b) => a.localeCompare(b, "zh-Hant"));
+}

--- a/src/lib/note.ts
+++ b/src/lib/note.ts
@@ -1,5 +1,3 @@
-export const NOTE_TAG_LIMIT = 20;
-
 export function normalizeNoteTags(input: unknown): string[] {
   if (!Array.isArray(input)) {
     return [];

--- a/src/lib/note.ts
+++ b/src/lib/note.ts
@@ -1,0 +1,10 @@
+export const NOTE_CATEGORY_OPTIONS = [
+  { value: "general", label: "一般筆記" },
+  { value: "progress", label: "進度心得" },
+  { value: "insight", label: "觀後感" },
+  { value: "reference", label: "資料整理" },
+] as const;
+
+export type NoteCategory = (typeof NOTE_CATEGORY_OPTIONS)[number]["value"];
+
+export const NOTE_TAG_LIMIT = 20;

--- a/src/lib/opengraph.ts
+++ b/src/lib/opengraph.ts
@@ -1,6 +1,8 @@
 type OpenGraphMetadata = {
   image: string | null;
   title: string | null;
+  description: string | null;
+  siteName: string | null;
 };
 
 export async function fetchOpenGraphMetadata(
@@ -30,9 +32,22 @@ export async function fetchOpenGraphMetadata(
         typeof image === "string" ? image.trim() || null : null;
       const normalizedTitle =
         typeof title === "string" ? title.trim() || null : null;
-      return { image: normalizedImage, title: normalizedTitle };
+      const normalizedDescription =
+        "description" in data && typeof (data as { description?: unknown }).description === "string"
+          ? ((data as { description?: unknown }).description as string).trim() || null
+          : null;
+      const normalizedSiteName =
+        "siteName" in data && typeof (data as { siteName?: unknown }).siteName === "string"
+          ? ((data as { siteName?: unknown }).siteName as string).trim() || null
+          : null;
+      return {
+        image: normalizedImage,
+        title: normalizedTitle,
+        description: normalizedDescription,
+        siteName: normalizedSiteName,
+      };
     }
-    return { image: null, title: null };
+    return { image: null, title: null, description: null, siteName: null };
   } catch {
     return null;
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -79,6 +79,9 @@ export type ItemLink = {
   label: string;
   url: string;
   isPrimary?: boolean;
+  title?: string | null;
+  description?: string | null;
+  siteName?: string | null;
 };
 
 export type AppearanceRecord = {

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -234,7 +234,22 @@ export function parseItemForm(input: ItemFormInput): ItemFormData {
       if (isPrimary) {
         hasPrimary = true;
       }
-      return { label, url, isPrimary };
+      const linkTitle =
+        typeof link.title === "string" ? link.title.trim() || null : null;
+      const linkDescription =
+        typeof link.description === "string"
+          ? link.description.trim() || null
+          : null;
+      const linkSiteName =
+        typeof link.siteName === "string" ? link.siteName.trim() || null : null;
+      return {
+        label,
+        url,
+        isPrimary,
+        title: linkTitle,
+        description: linkDescription,
+        siteName: linkSiteName,
+      };
     });
     if (!hasPrimary && links.length > 0) {
       links[0] = { ...links[0], isPrimary: true };


### PR DESCRIPTION
## Summary
- extend note creation and editing to manage categories, tags, linked cabinets/items, and provide markdown preview/sync tools
- enrich note list and detail views with target badges, advanced filters, and dual rich text/markdown presentation
- surface item-linked notes with quick navigation and unlink controls while introducing shared note utilities

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d51dd389fc832088020d00315ab52e