### PR TITLE
Enhance Open Graph fetch reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 
 # testing
 /coverage
+test-dist/
 
 # next.js
 /.next/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,7 @@ const eslintConfig = [
       "out/**",
       "build/**",
       "next-env.d.ts",
+      "test-dist/**",
     ],
   },
 ];

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "npm run test:build && node test-dist/test/open-graph.test.js",
+    "test:build": "tsc -p tsconfig.test.json"
   },
   "dependencies": {
     "firebase": "^12.2.1",

--- a/test/open-graph.test.ts
+++ b/test/open-graph.test.ts
@@ -1,0 +1,75 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { NextRequest } from "next/server";
+import { GET } from "../src/app/api/open-graph/route";
+
+const TEST_URL = "https://example.com/article";
+
+interface MinimalRequest {
+  nextUrl: URL;
+}
+
+function createRequest(url: string): MinimalRequest {
+  return {
+    nextUrl: new URL(
+      `http://localhost/api/open-graph?url=${encodeURIComponent(url)}`
+    ),
+  };
+}
+
+test("GET uses JSON-LD metadata as fallback", async () => {
+  const originalFetch = globalThis.fetch;
+
+  const html = `<!DOCTYPE html>
+  <html lang="en">
+    <head>
+      <meta charset="utf-8" />
+      <script type="application/ld+json">{ invalid json }</script>
+      <script type="application/ld+json">
+        {"@context":"https://schema.org","@type":"NewsArticle","headline":"JSON-LD Headline","author":{"@type":"Person","name":"Jane Doe"},"publisher":{"@type":"Organization","name":"Example Publisher"}}
+      </script>
+    </head>
+    <body>
+      <h1>Sample Article</h1>
+    </body>
+  </html>`;
+
+  const requests: RequestInit[] = [];
+
+  globalThis.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+    if (init) {
+      requests.push(init);
+    }
+    return new Response(html, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/html; charset=utf-8",
+      },
+    });
+  };
+
+  try {
+    const response = await GET(createRequest(TEST_URL) as unknown as NextRequest);
+    assert.equal(response.status, 200);
+
+    const payload = await response.json();
+    assert.deepEqual(payload, {
+      image: null,
+      title: "JSON-LD Headline",
+      author: "Jane Doe",
+      siteName: "Example Publisher",
+    });
+
+    assert.ok(requests.length > 0, "fetch should be invoked");
+    const [init] = requests;
+    const headers = new Headers(init.headers);
+    assert.equal(
+      headers.get("User-Agent"),
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
+    );
+    assert.equal(headers.get("Accept-Language"), "en-US,en;q=0.9");
+    assert.equal(headers.get("Sec-Fetch-Mode"), "navigate");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "emitDeclarationOnly": false,
+    "outDir": "test-dist",
+    "module": "commonjs",
+    "target": "ES2020",
+    "moduleResolution": "node",
+    "isolatedModules": false,
+    "allowJs": false,
+    "resolveJsonModule": true
+  },
+  "include": [
+    "src/app/api/open-graph/route.ts",
+    "test/open-graph.test.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- add browser-like request headers to the Open Graph API fetch so that sites return complete HTML
- parse JSON-LD data for fallback metadata fields when conventional meta tags are missing
- add a TypeScript build-and-run test harness that covers JSON-LD extraction behavior

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68d9eabef3588320b0c30fa8894748e7