### PR TITLE
feat: link notes with related items

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -11,8 +11,22 @@ service cloud.firestore {
       return field == null || (field is string && field.size() <= maxLen);
     }
 
+    function isOptionalNonEmptyString(field, maxLen) {
+      return field == null || (field is string && field.size() >= 1 && field.size() <= maxLen);
+    }
+
     function isTimestamp(value) {
       return value is timestamp;
+    }
+
+    function isStringList(list, maxItems, maxLen) {
+      return list is list
+        && list.size() <= maxItems
+        && (list.size() == 0
+            || (list[0] is string
+                && list[0].size() >= 1
+                && list[0].size() <= maxLen
+                && isStringList(list.slice(1, list.size()), maxItems, maxLen)));
     }
 
     function isValidNoteData(data) {
@@ -20,6 +34,11 @@ service cloud.firestore {
         && isNonEmptyString(data.title, 100)
         && isNonEmptyString(data.content, 60000)
         && ("description" in data ? isOptionalString(data.description, 300) : true)
+        && ("cabinetId" in data ? isOptionalNonEmptyString(data.cabinetId, 128) : true)
+        && ("itemId" in data ? isOptionalNonEmptyString(data.itemId, 128) : true)
+        && ("relatedItemIds" in data
+            ? (data.relatedItemIds == null || isStringList(data.relatedItemIds, 50, 128))
+            : true)
         && isTimestamp(data.createdAt)
         && isTimestamp(data.updatedAt);
     }

--- a/src/app/notes/[id]/page.tsx
+++ b/src/app/notes/[id]/page.tsx
@@ -7,7 +7,15 @@ import { onAuthStateChanged, type User } from "firebase/auth";
 import { deleteDoc, doc, onSnapshot, serverTimestamp, Timestamp, updateDoc } from "firebase/firestore";
 
 import { RichTextEditor, extractPlainTextFromHtml } from "@/components/RichTextEditor";
+import { fetchCabinetOptions, type CabinetOption } from "@/lib/cabinet-options";
 import { getFirebaseAuth, getFirebaseDb } from "@/lib/firebase";
+import {
+  buildItemListFromSummaries,
+  describeCabinet,
+  loadItemSummaries,
+  normalizeNoteRelations,
+  type ItemSummary,
+} from "@/lib/note-relations";
 import { buttonClass } from "@/lib/ui";
 
 type PageProps = {
@@ -22,6 +30,9 @@ type Note = {
   isFavorite: boolean;
   createdMs: number;
   updatedMs: number;
+  cabinetId: string | null;
+  itemId: string | null;
+  relatedItemIds: string[];
 };
 
 type Feedback = {
@@ -63,6 +74,12 @@ export default function NoteDetailPage({ params }: PageProps) {
   const [quickEditText, setQuickEditText] = useState("");
   const [quickEditSaving, setQuickEditSaving] = useState(false);
   const [quickEditError, setQuickEditError] = useState<string | null>(null);
+  const [cabinetOptions, setCabinetOptions] = useState<CabinetOption[]>([]);
+  const [cabinetLoading, setCabinetLoading] = useState(false);
+  const [cabinetError, setCabinetError] = useState<string | null>(null);
+  const [relatedItems, setRelatedItems] = useState<ItemSummary[]>([]);
+  const [relationsLoading, setRelationsLoading] = useState(false);
+  const [relationsError, setRelationsError] = useState<string | null>(null);
 
   useEffect(() => {
     const auth = getFirebaseAuth();
@@ -79,6 +96,40 @@ export default function NoteDetailPage({ params }: PageProps) {
     });
     return () => unsub();
   }, []);
+
+  useEffect(() => {
+    if (!user) {
+      setCabinetOptions([]);
+      setCabinetError(null);
+      return;
+    }
+    let active = true;
+    setCabinetLoading(true);
+    setCabinetError(null);
+    fetchCabinetOptions(user.uid)
+      .then((options) => {
+        if (!active) {
+          return;
+        }
+        setCabinetOptions(options);
+      })
+      .catch((err) => {
+        console.error("載入櫃子資料時發生錯誤", err);
+        if (!active) {
+          return;
+        }
+        setCabinetError("載入櫃子資料時發生錯誤");
+      })
+      .finally(() => {
+        if (!active) {
+          return;
+        }
+        setCabinetLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [user]);
 
   useEffect(() => {
     if (!authChecked) {
@@ -119,6 +170,7 @@ export default function NoteDetailPage({ params }: PageProps) {
         const updatedAt = data.updatedAt;
         const createdMs = createdAt instanceof Timestamp ? createdAt.toMillis() : 0;
         const updatedMs = updatedAt instanceof Timestamp ? updatedAt.toMillis() : createdMs;
+        const relations = normalizeNoteRelations(data as Record<string, unknown>);
         setNote({
           id: snap.id,
           title: (data.title as string) || "",
@@ -130,6 +182,9 @@ export default function NoteDetailPage({ params }: PageProps) {
           isFavorite: Boolean(data.isFavorite),
           createdMs,
           updatedMs,
+          cabinetId: relations.cabinetId,
+          itemId: relations.itemId,
+          relatedItemIds: relations.relatedItemIds,
         });
         setFeedback(null);
         setLoading(false);
@@ -141,6 +196,57 @@ export default function NoteDetailPage({ params }: PageProps) {
     );
     return () => unsub();
   }, [authChecked, noteId, user]);
+
+  const relatedKey = note ? note.relatedItemIds.join("|") : "";
+
+  useEffect(() => {
+    if (!user || !note) {
+      setRelatedItems([]);
+      setRelationsError(null);
+      setRelationsLoading(false);
+      return;
+    }
+    if (note.relatedItemIds.length === 0) {
+      setRelatedItems([]);
+      setRelationsError(null);
+      setRelationsLoading(false);
+      return;
+    }
+    let active = true;
+    setRelationsLoading(true);
+    setRelationsError(null);
+    loadItemSummaries(user.uid, note.relatedItemIds)
+      .then((map) => {
+        if (!active) {
+          return;
+        }
+        const list = buildItemListFromSummaries(note.relatedItemIds, map);
+        setRelatedItems(list);
+      })
+      .catch((err) => {
+        console.error("載入關聯作品時發生錯誤", err);
+        if (!active) {
+          return;
+        }
+        setRelationsError("載入關聯作品時發生錯誤");
+        const placeholders = note.relatedItemIds.map((id) => ({
+          id,
+          title: "(找不到作品)",
+          cabinetId: null,
+          isMissing: true,
+        } satisfies ItemSummary));
+        setRelatedItems(placeholders);
+      })
+      .finally(() => {
+        if (!active) {
+          return;
+        }
+        setRelationsLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [note, relatedKey, user]);
 
   const metaInfo = useMemo(() => {
     if (!note) {
@@ -159,6 +265,116 @@ export default function NoteDetailPage({ params }: PageProps) {
       </dl>
     );
   }, [note]);
+
+  const cabinetMap = useMemo(() => {
+    const map = new Map<string, CabinetOption>();
+    cabinetOptions.forEach((option) => {
+      map.set(option.id, option);
+    });
+    return map;
+  }, [cabinetOptions]);
+
+  const relationInfo = useMemo(() => {
+    if (!note) {
+      return null;
+    }
+    const cabinetInfo = describeCabinet(note.cabinetId, cabinetMap);
+    const cabinetContent = note.cabinetId ? (
+      cabinetInfo.missing ? (
+        <span className="text-sm text-red-600">{cabinetInfo.name}</span>
+      ) : cabinetInfo.isLocked ? (
+        <span className="inline-flex items-center gap-1 text-sm text-amber-600">
+          <span aria-hidden="true">🔒</span>
+          {cabinetInfo.name}
+        </span>
+      ) : (
+        <Link
+          href={`/cabinet/${encodeURIComponent(note.cabinetId)}`}
+          className="text-sm text-blue-600 underline-offset-4 hover:underline"
+        >
+          {cabinetInfo.name}
+        </Link>
+      )
+    ) : (
+      <span className="text-sm text-gray-600">未指定</span>
+    );
+
+    const itemsContent = relationsLoading ? (
+      <div className="rounded-xl border border-dashed border-gray-200 bg-white px-4 py-3 text-sm text-gray-500">
+        正在載入關聯作品…
+      </div>
+    ) : relationsError ? (
+      <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">{relationsError}</div>
+    ) : relatedItems.length === 0 ? (
+      <p className="text-sm text-gray-500">尚未關聯任何作品。</p>
+    ) : (
+      <ul className="space-y-2">
+        {relatedItems.map((item) => {
+          const cabinet = item.cabinetId ? cabinetMap.get(item.cabinetId) ?? null : null;
+          const cabinetLabel = item.cabinetId
+            ? cabinet
+              ? `${cabinet.name || "未命名櫃子"}${cabinet.isLocked ? "（已鎖定）" : ""}`
+              : "(找不到櫃子)"
+            : "未指定櫃子";
+          const isLocked = Boolean(cabinet?.isLocked);
+          const isPrimary = note.itemId === item.id;
+          const content = item.isMissing ? (
+            <span className="font-medium text-red-600">{item.title}</span>
+          ) : isLocked ? (
+            <span className="inline-flex items-center gap-1 font-medium text-amber-600">
+              <span aria-hidden="true">🔒</span>
+              {item.title}
+            </span>
+          ) : (
+            <Link
+              href={`/item/${encodeURIComponent(item.id)}`}
+              className="font-medium text-blue-600 underline-offset-4 hover:underline"
+            >
+              {item.title}
+            </Link>
+          );
+          return (
+            <li key={item.id} className="rounded-xl border border-gray-200 bg-gray-50 px-3 py-2">
+              <div className="flex flex-wrap items-center gap-2">
+                {content}
+                {isPrimary ? (
+                  <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-700">
+                    主作品
+                  </span>
+                ) : null}
+              </div>
+              <div className="text-xs text-gray-500">{cabinetLabel}</div>
+            </li>
+          );
+        })}
+      </ul>
+    );
+
+    const hasContent =
+      note.cabinetId || cabinetError || relatedItems.length > 0 || relationsLoading || relationsError;
+
+    return (
+      <section className="space-y-4 rounded-2xl border bg-white/70 p-6 shadow-sm">
+        <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+          <h2 className="text-lg font-semibold text-gray-900">關聯作品 / 櫃子</h2>
+          {cabinetLoading ? <span className="text-xs text-gray-400">正在載入櫃子資訊…</span> : null}
+        </div>
+        {cabinetError ? (
+          <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-600">{cabinetError}</div>
+        ) : null}
+        <div className="space-y-3 text-sm text-gray-700">
+          <div>
+            <div className="text-xs text-gray-500">關聯櫃子</div>
+            <div className="mt-1">{hasContent ? cabinetContent : <span className="text-sm text-gray-500">未指定</span>}</div>
+          </div>
+          <div>
+            <div className="text-xs text-gray-500">關聯作品</div>
+            <div className="mt-2">{itemsContent}</div>
+          </div>
+        </div>
+      </section>
+    );
+  }, [cabinetError, cabinetLoading, cabinetMap, note, relatedItems, relationsError, relationsLoading]);
 
   async function handleDelete() {
     if (!note || deleting) {
@@ -387,6 +603,7 @@ export default function NoteDetailPage({ params }: PageProps) {
               </div>
             </div>
           </header>
+          {relationInfo}
           {metaInfo}
           <section className="rounded-2xl border border-gray-200 bg-white/70 p-6 shadow-sm">
             <div className="mb-4 flex items-center justify-between gap-2">

--- a/src/app/notes/new/page.tsx
+++ b/src/app/notes/new/page.tsx
@@ -2,12 +2,19 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { FormEvent, useEffect, useState } from "react";
+import { FormEvent, useEffect, useMemo, useState } from "react";
 import { onAuthStateChanged, type User } from "firebase/auth";
 import { addDoc, collection, serverTimestamp } from "firebase/firestore";
 
 import { RichTextEditor } from "@/components/RichTextEditor";
+import NoteRelationDialog from "@/components/NoteRelationDialog";
+import { fetchCabinetOptions, type CabinetOption } from "@/lib/cabinet-options";
 import { getFirebaseAuth, getFirebaseDb } from "@/lib/firebase";
+import {
+  describeCabinet,
+  NOTE_RELATED_ITEM_LIMIT,
+  type ItemSummary,
+} from "@/lib/note-relations";
 import { buttonClass } from "@/lib/ui";
 
 const TITLE_LIMIT = 100;
@@ -29,6 +36,13 @@ export default function NewNotePage() {
   const [isFavorite, setIsFavorite] = useState(false);
   const [feedback, setFeedback] = useState<Feedback | null>(null);
   const [saving, setSaving] = useState(false);
+  const [relationDialogOpen, setRelationDialogOpen] = useState(false);
+  const [linkedCabinetId, setLinkedCabinetId] = useState<string | null>(null);
+  const [selectedItems, setSelectedItems] = useState<ItemSummary[]>([]);
+  const [primaryItemId, setPrimaryItemId] = useState<string | null>(null);
+  const [cabinetOptions, setCabinetOptions] = useState<CabinetOption[]>([]);
+  const [cabinetLoading, setCabinetLoading] = useState(false);
+  const [cabinetError, setCabinetError] = useState<string | null>(null);
 
   useEffect(() => {
     const auth = getFirebaseAuth();
@@ -43,6 +57,105 @@ export default function NewNotePage() {
     });
     return () => unsub();
   }, []);
+
+  useEffect(() => {
+    if (!user) {
+      setCabinetOptions([]);
+      setCabinetError(null);
+      return;
+    }
+    let active = true;
+    setCabinetLoading(true);
+    setCabinetError(null);
+    fetchCabinetOptions(user.uid)
+      .then((options) => {
+        if (!active) {
+          return;
+        }
+        setCabinetOptions(options);
+      })
+      .catch((err) => {
+        console.error("載入櫃子資料時發生錯誤", err);
+        if (!active) {
+          return;
+        }
+        setCabinetError("載入櫃子資料時發生錯誤");
+      })
+      .finally(() => {
+        if (!active) {
+          return;
+        }
+        setCabinetLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [user]);
+
+  const cabinetMap = useMemo(() => {
+    const map = new Map<string, CabinetOption>();
+    cabinetOptions.forEach((option) => {
+      map.set(option.id, option);
+    });
+    return map;
+  }, [cabinetOptions]);
+
+  const relationSummary = useMemo(() => {
+    const cabinetInfo = describeCabinet(linkedCabinetId, cabinetMap);
+    const items = selectedItems;
+    if (items.length === 0) {
+      return (
+        <div className="rounded-xl border border-dashed border-gray-200 bg-white px-4 py-5 text-sm text-gray-500">
+          尚未選擇任何作品，可按右上角按鈕管理關聯。
+        </div>
+      );
+    }
+    return (
+      <div className="space-y-3 rounded-xl border border-gray-200 bg-white px-4 py-5 text-sm text-gray-700">
+        <div>
+          <div className="text-xs text-gray-500">關聯櫃子</div>
+          <div className="mt-1 flex items-center gap-2 text-sm">
+            <span>{cabinetInfo.name}</span>
+            {cabinetInfo.missing ? (
+              <span className="text-xs text-red-600">已找不到或無法存取</span>
+            ) : cabinetInfo.isLocked ? (
+              <span className="text-xs text-amber-600">已鎖定</span>
+            ) : null}
+          </div>
+        </div>
+        <div className="space-y-2">
+          <div className="text-xs text-gray-500">關聯作品</div>
+          <ul className="space-y-2">
+            {items.map((item) => {
+              const cabinet = item.cabinetId ? cabinetMap.get(item.cabinetId) ?? null : null;
+              const cabinetLabel = item.cabinetId
+                ? cabinet
+                  ? `${cabinet.name || "未命名櫃子"}${cabinet.isLocked ? "（已鎖定）" : ""}`
+                  : "(找不到櫃子)"
+                : "未指定櫃子";
+              const isPrimary = primaryItemId === item.id;
+              return (
+                <li key={item.id} className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-medium text-gray-800">{item.title}</span>
+                    {item.isMissing ? (
+                      <span className="text-xs text-red-600">資料遺失</span>
+                    ) : null}
+                    {isPrimary ? (
+                      <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-700">
+                        主作品
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="text-xs text-gray-500">{cabinetLabel}</div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </div>
+    );
+  }, [cabinetMap, linkedCabinetId, primaryItemId, selectedItems]);
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -80,6 +193,12 @@ export default function NewNotePage() {
       return;
     }
 
+    const relatedIds = selectedItems.map((item) => item.id).slice(0, NOTE_RELATED_ITEM_LIMIT);
+    const normalizedPrimary = primaryItemId && relatedIds.includes(primaryItemId)
+      ? primaryItemId
+      : relatedIds[0] ?? null;
+    const normalizedCabinet = linkedCabinetId ?? null;
+
     setSaving(true);
     setFeedback(null);
 
@@ -90,6 +209,9 @@ export default function NewNotePage() {
         description: trimmedDescription ? trimmedDescription : null,
         content: sanitizedContentHtml,
         isFavorite,
+        cabinetId: normalizedCabinet,
+        itemId: normalizedPrimary,
+        relatedItemIds: relatedIds,
         createdAt: serverTimestamp(),
         updatedAt: serverTimestamp(),
       });
@@ -99,6 +221,9 @@ export default function NewNotePage() {
       setContentHtml("");
       setContentText("");
       setIsFavorite(false);
+      setLinkedCabinetId(null);
+      setSelectedItems([]);
+      setPrimaryItemId(null);
       router.replace("/notes");
     } catch (err) {
       console.error("新增筆記時發生錯誤", err);
@@ -140,88 +265,131 @@ export default function NewNotePage() {
   }
 
   return (
-    <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
-      <div className="mx-auto w-full max-w-2xl space-y-6">
-        <header className="space-y-2">
-          <h1 className="text-2xl font-semibold text-gray-900">新增筆記</h1>
-          <p className="text-sm text-gray-500">建立新的筆記並記錄重要資訊。</p>
-        </header>
-        <section className="rounded-2xl border bg-white/70 p-6 shadow-sm">
-          <form className="space-y-6" onSubmit={handleSubmit}>
-            <label className="block space-y-2">
-              <span className="text-sm font-medium text-gray-700">筆記標題</span>
-              <input
-                value={title}
-                onChange={(event) => setTitle(event.target.value)}
-                placeholder="輸入筆記標題"
-                maxLength={TITLE_LIMIT}
-                required
-                className="h-12 w-full rounded-xl border px-4 text-base"
-                autoFocus
-              />
-              <span className="block text-right text-xs text-gray-400">
-                {title.trim().length}/{TITLE_LIMIT}
-              </span>
-            </label>
-            <label className="block space-y-2">
-              <span className="text-sm font-medium text-gray-700">筆記備註</span>
-              <textarea
-                value={description}
-                onChange={(event) => setDescription(event.target.value)}
-                placeholder="補充筆記相關備註（選填）"
-                maxLength={DESCRIPTION_LIMIT}
-                className="min-h-[100px] w-full resize-y rounded-xl border px-4 py-3 text-base"
-              />
-              <span className="block text-right text-xs text-gray-400">
-                {description.trim().length}/{DESCRIPTION_LIMIT}
-              </span>
-            </label>
-            <label className="flex items-center gap-2 text-sm text-gray-700">
-              <input
-                type="checkbox"
-                checked={isFavorite}
-                onChange={(event) => setIsFavorite(event.target.checked)}
-                className="h-4 w-4 rounded border-gray-300 text-amber-500 focus:ring-amber-400"
-              />
-              設為最愛
-            </label>
-            <div className="space-y-2">
-              <span className="text-sm font-medium text-gray-700">筆記內容</span>
-              <RichTextEditor
-                value={contentHtml}
-                onChange={({ html, text }) => {
-                  setContentHtml(html);
-                  setContentText(text);
-                }}
-                placeholder="輸入筆記內容"
-              />
-            </div>
-            {feedback ? (
-              <div
-                className={
-                  feedback.type === "error"
-                    ? "break-anywhere rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700"
-                    : "break-anywhere rounded-xl bg-emerald-50 px-4 py-3 text-sm text-emerald-700"
-                }
-              >
-                {feedback.message}
+    <>
+      <main className="min-h-[100dvh] bg-gray-50 px-4 py-8">
+        <div className="mx-auto w-full max-w-2xl space-y-6">
+          <header className="space-y-2">
+            <h1 className="text-2xl font-semibold text-gray-900">新增筆記</h1>
+            <p className="text-sm text-gray-500">建立新的筆記並記錄重要資訊。</p>
+          </header>
+          <section className="rounded-2xl border bg-white/70 p-6 shadow-sm">
+            <form className="space-y-6" onSubmit={handleSubmit}>
+              <label className="block space-y-2">
+                <span className="text-sm font-medium text-gray-700">筆記標題</span>
+                <input
+                  value={title}
+                  onChange={(event) => setTitle(event.target.value)}
+                  placeholder="輸入筆記標題"
+                  maxLength={TITLE_LIMIT}
+                  required
+                  className="h-12 w-full rounded-xl border px-4 text-base"
+                  autoFocus
+                />
+                <span className="block text-right text-xs text-gray-400">
+                  {title.trim().length}/{TITLE_LIMIT}
+                </span>
+              </label>
+              <label className="block space-y-2">
+                <span className="text-sm font-medium text-gray-700">筆記備註</span>
+                <textarea
+                  value={description}
+                  onChange={(event) => setDescription(event.target.value)}
+                  placeholder="補充筆記相關備註（選填）"
+                  maxLength={DESCRIPTION_LIMIT}
+                  className="min-h-[100px] w-full resize-y rounded-xl border px-4 py-3 text-base"
+                />
+                <span className="block text-right text-xs text-gray-400">
+                  {description.trim().length}/{DESCRIPTION_LIMIT}
+                </span>
+              </label>
+              <div className="space-y-3">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <span className="text-sm font-medium text-gray-700">關聯作品 / 櫃子</span>
+                    <p className="text-xs text-gray-500">選擇要關聯的作品或櫃子，建立資料之間的連結。</p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setRelationDialogOpen(true)}
+                    className={buttonClass({ variant: "secondary", size: "sm" })}
+                  >
+                    管理關聯
+                  </button>
+                </div>
+                {cabinetError ? (
+                  <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-2 text-xs text-red-600">
+                    {cabinetError}
+                  </div>
+                ) : null}
+                {cabinetLoading && cabinetOptions.length === 0 ? (
+                  <div className="rounded-xl border border-dashed border-gray-200 bg-white px-4 py-4 text-sm text-gray-500">
+                    正在載入櫃子資訊…
+                  </div>
+                ) : (
+                  relationSummary
+                )}
               </div>
-            ) : null}
-            <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
-              <Link href="/notes" className={`${buttonClass({ variant: "secondary" })} w-full sm:w-auto`}>
-                取消
-              </Link>
-              <button
-                type="submit"
-                disabled={saving}
-                className={`${buttonClass({ variant: "primary" })} w-full sm:w-auto`}
-              >
-                {saving ? "儲存中…" : "儲存"}
-              </button>
-            </div>
-          </form>
-        </section>
-      </div>
-    </main>
+              <label className="flex items-center gap-2 text-sm text-gray-700">
+                <input
+                  type="checkbox"
+                  checked={isFavorite}
+                  onChange={(event) => setIsFavorite(event.target.checked)}
+                  className="h-4 w-4 rounded border-gray-300 text-amber-500 focus:ring-amber-400"
+                />
+                設為最愛
+              </label>
+              <div className="space-y-2">
+                <span className="text-sm font-medium text-gray-700">筆記內容</span>
+                <RichTextEditor
+                  value={contentHtml}
+                  onChange={({ html, text }) => {
+                    setContentHtml(html);
+                    setContentText(text);
+                  }}
+                  placeholder="輸入筆記內容"
+                />
+              </div>
+              {feedback ? (
+                <div
+                  className={
+                    feedback.type === "error"
+                      ? "break-anywhere rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700"
+                      : "break-anywhere rounded-xl bg-emerald-50 px-4 py-3 text-sm text-emerald-700"
+                  }
+                >
+                  {feedback.message}
+                </div>
+              ) : null}
+              <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+                <Link href="/notes" className={`${buttonClass({ variant: "secondary" })} w-full sm:w-auto`}>
+                  取消
+                </Link>
+                <button
+                  type="submit"
+                  disabled={saving}
+                  className={`${buttonClass({ variant: "primary" })} w-full sm:w-auto`}
+                >
+                  {saving ? "儲存中…" : "儲存"}
+                </button>
+              </div>
+            </form>
+          </section>
+        </div>
+      </main>
+      <NoteRelationDialog
+        open={relationDialogOpen}
+        userId={user.uid}
+        initialCabinetId={linkedCabinetId}
+        initialItems={selectedItems}
+        initialPrimaryItemId={primaryItemId}
+        onClose={() => setRelationDialogOpen(false)}
+        onSave={({ cabinetId, items, primaryItemId: primary }) => {
+          setLinkedCabinetId(cabinetId);
+          setSelectedItems(items);
+          setPrimaryItemId(primary);
+          setRelationDialogOpen(false);
+        }}
+      />
+    </>
   );
 }

--- a/src/components/NoteRelationDialog.tsx
+++ b/src/components/NoteRelationDialog.tsx
@@ -1,0 +1,540 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { fetchCabinetOptions, type CabinetOption } from "@/lib/cabinet-options";
+import {
+  NOTE_RELATED_ITEM_LIMIT,
+  fetchCabinetItemSummaries,
+  type ItemSummary,
+} from "@/lib/note-relations";
+import { buttonClass } from "@/lib/ui";
+
+type NoteRelationDialogProps = {
+  open: boolean;
+  userId: string;
+  initialCabinetId: string | null;
+  initialItems: ItemSummary[];
+  initialPrimaryItemId: string | null;
+  onClose: () => void;
+  onSave: (value: {
+    cabinetId: string | null;
+    items: ItemSummary[];
+    primaryItemId: string | null;
+  }) => void;
+};
+
+const INITIAL_MAP = () => new Map<string, ItemSummary>();
+
+export default function NoteRelationDialog({
+  open,
+  userId,
+  initialCabinetId,
+  initialItems,
+  initialPrimaryItemId,
+  onClose,
+  onSave,
+}: NoteRelationDialogProps) {
+  const [cabinetOptions, setCabinetOptions] = useState<CabinetOption[]>([]);
+  const [cabinetLoading, setCabinetLoading] = useState(false);
+  const [cabinetError, setCabinetError] = useState<string | null>(null);
+  const [cabinetSearch, setCabinetSearch] = useState("");
+  const [activeCabinetId, setActiveCabinetId] = useState<string | null>(initialCabinetId);
+  const [linkedCabinetId, setLinkedCabinetId] = useState<string | null>(initialCabinetId);
+  const [itemsCache, setItemsCache] = useState(() => new Map<string, ItemSummary[]>());
+  const [itemSearch, setItemSearch] = useState("");
+  const [itemsLoading, setItemsLoading] = useState(false);
+  const [itemsError, setItemsError] = useState<string | null>(null);
+  const [selectedItems, setSelectedItems] = useState<Map<string, ItemSummary>>(INITIAL_MAP);
+  const [primaryItemId, setPrimaryItemId] = useState<string | null>(
+    initialPrimaryItemId ?? (initialItems[0]?.id ?? null)
+  );
+  const [selectionError, setSelectionError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    setCabinetLoading(true);
+    setCabinetError(null);
+    let active = true;
+    fetchCabinetOptions(userId)
+      .then((options) => {
+        if (!active) {
+          return;
+        }
+        setCabinetOptions(options);
+      })
+      .catch((err) => {
+        console.error("載入櫃子列表時發生錯誤", err);
+        if (!active) {
+          return;
+        }
+        setCabinetError("載入櫃子列表時發生錯誤");
+      })
+      .finally(() => {
+        if (!active) {
+          return;
+        }
+        setCabinetLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [open, userId]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const initialMap = new Map<string, ItemSummary>();
+    initialItems.forEach((item) => {
+      initialMap.set(item.id, item);
+    });
+    setSelectedItems(initialMap);
+    setPrimaryItemId((prev) => {
+      if (prev && initialMap.has(prev)) {
+        return prev;
+      }
+      if (initialPrimaryItemId && initialMap.has(initialPrimaryItemId)) {
+        return initialPrimaryItemId;
+      }
+      const first = initialMap.values().next().value as ItemSummary | undefined;
+      return first ? first.id : null;
+    });
+    setLinkedCabinetId(initialCabinetId ?? null);
+    setActiveCabinetId(initialCabinetId ?? null);
+    setSelectionError(null);
+  }, [initialCabinetId, initialItems, initialPrimaryItemId, open]);
+
+  useEffect(() => {
+    if (!open || !activeCabinetId) {
+      return;
+    }
+    if (itemsCache.has(activeCabinetId)) {
+      return;
+    }
+    let cancelled = false;
+    setItemsLoading(true);
+    setItemsError(null);
+    fetchCabinetItemSummaries(userId, activeCabinetId)
+      .then((items) => {
+        if (cancelled) {
+          return;
+        }
+        setItemsCache((prev) => {
+          const next = new Map(prev);
+          next.set(activeCabinetId, items);
+          return next;
+        });
+      })
+      .catch((err) => {
+        console.error("載入作品列表時發生錯誤", err);
+        if (cancelled) {
+          return;
+        }
+        setItemsError("載入作品列表時發生錯誤");
+      })
+      .finally(() => {
+        if (cancelled) {
+          return;
+        }
+        setItemsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeCabinetId, itemsCache, open, userId]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onClose, open]);
+
+  const cabinetMap = useMemo(() => {
+    const map = new Map<string, CabinetOption>();
+    cabinetOptions.forEach((option) => {
+      map.set(option.id, option);
+    });
+    return map;
+  }, [cabinetOptions]);
+
+  const filteredCabinets = useMemo(() => {
+    const keyword = cabinetSearch.trim().toLowerCase();
+    if (!keyword) {
+      return cabinetOptions;
+    }
+    return cabinetOptions.filter((option) =>
+      option.name.toLowerCase().includes(keyword)
+    );
+  }, [cabinetOptions, cabinetSearch]);
+
+  const activeItems = useMemo(() => {
+    if (!activeCabinetId) {
+      return [] as ItemSummary[];
+    }
+    const source = itemsCache.get(activeCabinetId) ?? [];
+    const keyword = itemSearch.trim().toLowerCase();
+    if (!keyword) {
+      return source;
+    }
+    return source.filter((item) => item.title.toLowerCase().includes(keyword));
+  }, [activeCabinetId, itemSearch, itemsCache]);
+
+  const selectedList = useMemo(() => Array.from(selectedItems.values()), [selectedItems]);
+
+  const activeCabinet = activeCabinetId ? cabinetMap.get(activeCabinetId) ?? null : null;
+  const linkedCabinet = linkedCabinetId ? cabinetMap.get(linkedCabinetId) ?? null : null;
+
+  if (!open) {
+    return null;
+  }
+
+  function toggleItem(item: ItemSummary) {
+    setSelectionError(null);
+    setSelectedItems((prev) => {
+      const next = new Map(prev);
+      if (next.has(item.id)) {
+        next.delete(item.id);
+      } else {
+        if (next.size >= NOTE_RELATED_ITEM_LIMIT) {
+          setSelectionError(`最多僅能連結 ${NOTE_RELATED_ITEM_LIMIT} 件作品`);
+          return prev;
+        }
+        next.set(item.id, { ...item, isMissing: item.isMissing });
+      }
+      setPrimaryItemId((prevPrimary) => {
+        if (next.size === 0) {
+          return null;
+        }
+        if (prevPrimary && next.has(prevPrimary)) {
+          return prevPrimary;
+        }
+        const first = next.values().next().value as ItemSummary | undefined;
+        return first ? first.id : null;
+      });
+      return next;
+    });
+  }
+
+  function removeItem(itemId: string) {
+    setSelectedItems((prev) => {
+      if (!prev.has(itemId)) {
+        return prev;
+      }
+      const next = new Map(prev);
+      next.delete(itemId);
+      setPrimaryItemId((prevPrimary) => {
+        if (next.size === 0) {
+          return null;
+        }
+        if (prevPrimary && next.has(prevPrimary)) {
+          return prevPrimary;
+        }
+        const first = next.values().next().value as ItemSummary | undefined;
+        return first ? first.id : null;
+      });
+      return next;
+    });
+  }
+
+  function handleApply() {
+    const list = Array.from(selectedItems.values());
+    const normalizedPrimary = (() => {
+      if (!primaryItemId) {
+        return list[0]?.id ?? null;
+      }
+      return selectedItems.has(primaryItemId) ? primaryItemId : list[0]?.id ?? null;
+    })();
+    onSave({
+      cabinetId: linkedCabinetId ?? null,
+      items: list,
+      primaryItemId: normalizedPrimary,
+    });
+  }
+
+  const linkedCabinetLabel = linkedCabinetId
+    ? linkedCabinet
+      ? `${linkedCabinet.name || "未命名櫃子"}${linkedCabinet.isLocked ? "（已鎖定）" : ""}`
+      : "(找不到櫃子)"
+    : "未指定";
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-8"
+      role="dialog"
+      aria-modal="true"
+      onClick={onClose}
+    >
+      <div
+        className="flex h-[90vh] w-full max-w-5xl flex-col gap-6 overflow-hidden rounded-3xl bg-white p-6 shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className="flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-2xl font-semibold text-gray-900">管理關聯作品 / 櫃子</h2>
+            <p className="mt-1 text-sm text-gray-500">
+              選擇櫃子後即可挑選作品加入筆記關聯，可多選並指定主要作品。
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="h-10 w-10 rounded-full border border-gray-200 text-xl text-gray-500 transition hover:border-gray-300 hover:text-gray-700"
+            aria-label="關閉關聯設定視窗"
+          >
+            ×
+          </button>
+        </header>
+
+        <div className="grid flex-1 gap-6 overflow-hidden lg:grid-cols-[minmax(0,22rem)_minmax(0,1fr)]">
+          <section className="flex h-full flex-col gap-4 overflow-hidden rounded-2xl border border-gray-200 bg-gray-50 p-4">
+            <div className="space-y-2">
+              <h3 className="text-lg font-semibold text-gray-800">選擇櫃子</h3>
+              <p className="text-sm text-gray-500">瀏覽櫃子以載入其包含的作品，並可指定作為筆記關聯櫃子。</p>
+            </div>
+            <input
+              value={cabinetSearch}
+              onChange={(event) => setCabinetSearch(event.target.value)}
+              placeholder="搜尋櫃子"
+              className="h-11 rounded-xl border border-gray-200 px-4 text-sm focus:border-gray-400 focus:outline-none"
+            />
+            <div className="relative flex-1 overflow-hidden rounded-xl border border-gray-200 bg-white">
+              <div className="absolute inset-0 overflow-y-auto p-2">
+                {cabinetLoading ? (
+                  <div className="p-4 text-center text-sm text-gray-500">正在載入櫃子…</div>
+                ) : cabinetError ? (
+                  <div className="p-4 text-center text-sm text-red-600">{cabinetError}</div>
+                ) : filteredCabinets.length === 0 ? (
+                  <div className="p-4 text-center text-sm text-gray-500">找不到符合的櫃子。</div>
+                ) : (
+                  <ul className="space-y-2">
+                    {filteredCabinets.map((cabinet) => {
+                      const isActive = cabinet.id === activeCabinetId;
+                      const isLinked = cabinet.id === linkedCabinetId;
+                      return (
+                        <li key={cabinet.id}>
+                          <button
+                            type="button"
+                            onClick={() => setActiveCabinetId(cabinet.id)}
+                            className={`flex w-full items-center justify-between gap-3 rounded-xl border px-3 py-2 text-left text-sm transition ${
+                              isActive
+                                ? "border-amber-400 bg-amber-50 text-amber-800"
+                                : "border-gray-200 bg-white text-gray-700 hover:border-gray-300 hover:bg-gray-50"
+                            }`}
+                          >
+                            <div className="min-w-0">
+                              <div className="truncate font-medium">
+                                {cabinet.name || "未命名櫃子"}
+                              </div>
+                              {cabinet.isLocked ? (
+                                <div className="text-xs text-amber-600">已鎖定</div>
+                              ) : null}
+                            </div>
+                            {isLinked ? (
+                              <span className="text-xs text-amber-600">已關聯</span>
+                            ) : null}
+                          </button>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
+              </div>
+            </div>
+            <div className="rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-600">
+              <div className="flex items-center justify-between gap-3">
+                <span className="font-medium text-gray-700">目前瀏覽櫃子</span>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    className={buttonClass({ variant: "secondary", size: "sm" })}
+                    onClick={() => {
+                      if (activeCabinetId) {
+                        setLinkedCabinetId(activeCabinetId);
+                      }
+                    }}
+                    disabled={!activeCabinetId}
+                  >
+                    關聯此櫃子
+                  </button>
+                  <button
+                    type="button"
+                    className={buttonClass({ variant: "ghost", size: "sm" })}
+                    onClick={() => setLinkedCabinetId(null)}
+                    disabled={!linkedCabinetId}
+                  >
+                    取消關聯
+                  </button>
+                </div>
+              </div>
+              <div className="mt-2 text-gray-700">
+                {activeCabinet
+                  ? `${activeCabinet.name || "未命名櫃子"}${activeCabinet.isLocked ? "（已鎖定）" : ""}`
+                  : "尚未選擇櫃子"}
+              </div>
+            </div>
+            <div className="rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-600">
+              <div className="font-medium text-gray-700">已關聯櫃子</div>
+              <div className="mt-2 break-anywhere text-gray-700">{linkedCabinetLabel}</div>
+            </div>
+          </section>
+
+          <section className="flex h-full flex-col gap-4 overflow-hidden rounded-2xl border border-gray-200 bg-white p-4">
+            <div className="space-y-2">
+              <h3 className="text-lg font-semibold text-gray-800">選擇作品</h3>
+              <p className="text-sm text-gray-500">
+                點擊作品即可加入或移除，已選的作品可在下方設定主要作品與移除。
+              </p>
+            </div>
+            {activeCabinetId ? (
+              <>
+                <input
+                  value={itemSearch}
+                  onChange={(event) => setItemSearch(event.target.value)}
+                  placeholder="搜尋作品"
+                  className="h-11 rounded-xl border border-gray-200 px-4 text-sm focus:border-gray-400 focus:outline-none"
+                />
+                <div className="relative flex-1 overflow-hidden rounded-xl border border-gray-200">
+                  <div className="absolute inset-0 overflow-y-auto p-2">
+                    {itemsLoading ? (
+                      <div className="p-4 text-center text-sm text-gray-500">正在載入作品…</div>
+                    ) : itemsError ? (
+                      <div className="p-4 text-center text-sm text-red-600">{itemsError}</div>
+                    ) : activeItems.length === 0 ? (
+                      <div className="p-4 text-center text-sm text-gray-500">此櫃子目前沒有作品或搜尋無結果。</div>
+                    ) : (
+                      <ul className="space-y-2">
+                        {activeItems.map((item) => {
+                          const isSelected = selectedItems.has(item.id);
+                          return (
+                            <li key={item.id}>
+                              <button
+                                type="button"
+                                onClick={() => toggleItem(item)}
+                                className={`flex w-full items-center justify-between gap-3 rounded-xl border px-3 py-2 text-left text-sm transition ${
+                                  isSelected
+                                    ? "border-amber-400 bg-amber-50 text-amber-800"
+                                    : "border-gray-200 bg-white text-gray-700 hover:border-gray-300 hover:bg-gray-50"
+                                }`}
+                              >
+                                <div className="min-w-0">
+                                  <div className="truncate font-medium">{item.title}</div>
+                                  {item.isMissing ? (
+                                    <div className="text-xs text-red-600">找不到作品資料</div>
+                                  ) : null}
+                                </div>
+                                <span className="text-base">{isSelected ? "✓" : "+"}</span>
+                              </button>
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    )}
+                  </div>
+                </div>
+              </>
+            ) : (
+              <div className="flex flex-1 items-center justify-center rounded-xl border border-dashed border-gray-300 bg-gray-50 text-sm text-gray-500">
+                請先於左側選擇櫃子。
+              </div>
+            )}
+
+            <div className="space-y-3 rounded-xl border border-gray-200 bg-gray-50 px-4 py-4">
+              <div className="flex items-center justify-between gap-3">
+                <h4 className="text-base font-semibold text-gray-800">已選作品</h4>
+                {selectionError ? (
+                  <span className="text-sm text-red-600">{selectionError}</span>
+                ) : null}
+              </div>
+              {selectedList.length === 0 ? (
+                <p className="text-sm text-gray-500">尚未選擇任何作品。</p>
+              ) : (
+                <ul className="space-y-3">
+                  {selectedList.map((item) => {
+                    const cabinet = item.cabinetId ? cabinetMap.get(item.cabinetId) ?? null : null;
+                    const cabinetText = item.cabinetId
+                      ? cabinet
+                        ? `${cabinet.name || "未命名櫃子"}${cabinet.isLocked ? "（已鎖定）" : ""}`
+                        : "(找不到櫃子)"
+                      : "未指定櫃子";
+                    const isPrimary = primaryItemId === item.id;
+                    return (
+                      <li key={item.id} className="rounded-xl border border-gray-200 bg-white px-3 py-3">
+                        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                          <div className="min-w-0 space-y-1">
+                            <div className="flex items-center gap-2">
+                              <span className="truncate text-sm font-medium text-gray-800">
+                                {item.title}
+                              </span>
+                              {item.isMissing ? (
+                                <span className="inline-flex items-center rounded-full bg-red-100 px-2 py-0.5 text-xs text-red-700">
+                                  已遺失
+                                </span>
+                              ) : null}
+                              {isPrimary ? (
+                                <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-700">
+                                  主作品
+                                </span>
+                              ) : null}
+                            </div>
+                            <div className="text-xs text-gray-500">{cabinetText}</div>
+                          </div>
+                          <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center">
+                            <label className="flex items-center gap-2 text-xs text-gray-600">
+                              <input
+                                type="radio"
+                                name="primaryItem"
+                                checked={isPrimary}
+                                onChange={() => setPrimaryItemId(item.id)}
+                              />
+                              設為主作品
+                            </label>
+                            <button
+                              type="button"
+                              className="text-xs text-red-600 transition hover:text-red-700"
+                              onClick={() => removeItem(item.id)}
+                            >
+                              移除
+                            </button>
+                          </div>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          </section>
+        </div>
+
+        <footer className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            className={`${buttonClass({ variant: "secondary" })} w-full sm:w-auto`}
+            onClick={onClose}
+          >
+            取消
+          </button>
+          <button
+            type="button"
+            className={`${buttonClass({ variant: "primary" })} w-full sm:w-auto`}
+            onClick={handleApply}
+          >
+            儲存關聯
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}
+

--- a/src/lib/note-relations.ts
+++ b/src/lib/note-relations.ts
@@ -1,0 +1,257 @@
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  query,
+  where,
+  type Firestore,
+} from "firebase/firestore";
+
+import { fetchCabinetOptions, type CabinetOption } from "./cabinet-options";
+import { getFirebaseDb } from "./firebase";
+
+export const NOTE_RELATED_ITEM_LIMIT = 50;
+
+export type NoteRelations = {
+  cabinetId: string | null;
+  itemId: string | null;
+  relatedItemIds: string[];
+};
+
+export type ItemSummary = {
+  id: string;
+  title: string;
+  cabinetId: string | null;
+  isMissing?: boolean;
+};
+
+type ItemSummaryCacheEntry = {
+  data: ItemSummary | null;
+  fetchedAt: number;
+};
+
+type CabinetItemsCacheEntry = {
+  data: ItemSummary[];
+  fetchedAt: number;
+};
+
+const ITEM_SUMMARY_CACHE_TTL_MS = 60_000;
+const CABINET_ITEMS_CACHE_TTL_MS = 60_000;
+
+const itemSummaryCache = new Map<string, ItemSummaryCacheEntry>();
+const itemSummaryPending = new Map<string, Promise<ItemSummary | null>>();
+const cabinetItemsCache = new Map<string, CabinetItemsCacheEntry>();
+const cabinetItemsPending = new Map<string, Promise<ItemSummary[]>>();
+
+function normalizeId(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function normalizeNoteRelations(
+  data: Record<string, unknown> | null | undefined
+): NoteRelations {
+  const cabinetId = normalizeId(data?.cabinetId);
+  const itemId = normalizeId(data?.itemId);
+  const relatedSource = Array.isArray(data?.relatedItemIds)
+    ? (data!.relatedItemIds as unknown[])
+    : [];
+  const unique = new Set<string>();
+  const relatedItemIds: string[] = [];
+  if (itemId) {
+    unique.add(itemId);
+    relatedItemIds.push(itemId);
+  }
+  for (const entry of relatedSource) {
+    const normalized = normalizeId(entry);
+    if (!normalized || unique.has(normalized)) {
+      continue;
+    }
+    unique.add(normalized);
+    relatedItemIds.push(normalized);
+    if (relatedItemIds.length >= NOTE_RELATED_ITEM_LIMIT) {
+      break;
+    }
+  }
+  return {
+    cabinetId,
+    itemId,
+    relatedItemIds,
+  };
+}
+
+function shouldUseCache(entry: ItemSummaryCacheEntry | CabinetItemsCacheEntry, ttl: number): boolean {
+  return Date.now() - entry.fetchedAt < ttl;
+}
+
+async function ensureDb(): Promise<Firestore> {
+  const db = getFirebaseDb();
+  if (!db) {
+    throw new Error("Firebase 尚未設定");
+  }
+  return db;
+}
+
+function buildItemSummary(data: Record<string, unknown>, id: string): ItemSummary {
+  const titleZh = typeof data.titleZh === "string" ? data.titleZh.trim() : "";
+  const titleAlt = typeof data.titleAlt === "string" ? data.titleAlt.trim() : "";
+  const title = titleZh || titleAlt || "(未命名物件)";
+  const cabinetId = normalizeId(data.cabinetId);
+  return { id, title, cabinetId } satisfies ItemSummary;
+}
+
+async function loadItemSummary(userId: string, itemId: string): Promise<ItemSummary | null> {
+  const cached = itemSummaryCache.get(itemId);
+  if (cached && shouldUseCache(cached, ITEM_SUMMARY_CACHE_TTL_MS)) {
+    return cached.data;
+  }
+  const pending = itemSummaryPending.get(itemId);
+  if (pending) {
+    return pending;
+  }
+  const request = (async () => {
+    try {
+      const db = await ensureDb();
+      const snap = await getDoc(doc(db, "item", itemId));
+      if (!snap.exists()) {
+        return null;
+      }
+      const data = snap.data();
+      if (!data || data.uid !== userId) {
+        return null;
+      }
+      const summary = buildItemSummary(data as Record<string, unknown>, itemId);
+      return summary;
+    } catch (err) {
+      console.error("載入作品摘要時發生錯誤", err);
+      return null;
+    }
+  })();
+  itemSummaryPending.set(itemId, request);
+  try {
+    const data = await request;
+    itemSummaryCache.set(itemId, { data, fetchedAt: Date.now() });
+    return data;
+  } finally {
+    itemSummaryPending.delete(itemId);
+  }
+}
+
+export async function loadItemSummaries(
+  userId: string,
+  itemIds: string[]
+): Promise<Map<string, ItemSummary | null>> {
+  const uniqueIds = Array.from(new Set(itemIds.map((id) => normalizeId(id)).filter(Boolean))) as string[];
+  const results = new Map<string, ItemSummary | null>();
+  await Promise.all(
+    uniqueIds.map(async (id) => {
+      const summary = await loadItemSummary(userId, id);
+      results.set(id, summary);
+    })
+  );
+  return results;
+}
+
+export function primeItemSummaryCache(items: ItemSummary[]): void {
+  const now = Date.now();
+  items.forEach((item) => {
+    itemSummaryCache.set(item.id, { data: item, fetchedAt: now });
+  });
+}
+
+export async function fetchCabinetItemSummaries(
+  userId: string,
+  cabinetId: string,
+  options: { forceRefresh?: boolean } = {}
+): Promise<ItemSummary[]> {
+  const cacheKey = `${userId}__${cabinetId}`;
+  const cached = cabinetItemsCache.get(cacheKey);
+  if (!options.forceRefresh && cached && shouldUseCache(cached, CABINET_ITEMS_CACHE_TTL_MS)) {
+    return cached.data;
+  }
+  if (!options.forceRefresh) {
+    const pending = cabinetItemsPending.get(cacheKey);
+    if (pending) {
+      return pending;
+    }
+  }
+  const request = (async () => {
+    try {
+      const db = await ensureDb();
+      const q = query(
+        collection(db, "item"),
+        where("uid", "==", userId),
+        where("cabinetId", "==", cabinetId)
+      );
+      const snap = await getDocs(q);
+      const rows = snap.docs.map((docSnap) => {
+        const data = docSnap.data() as Record<string, unknown>;
+        return buildItemSummary(data, docSnap.id);
+      });
+      rows.sort((a, b) => a.title.localeCompare(b.title, "zh-Hant", { sensitivity: "base" }));
+      primeItemSummaryCache(rows);
+      return rows;
+    } catch (err) {
+      console.error("載入櫃內作品列表時發生錯誤", err);
+      throw err;
+    }
+  })();
+  cabinetItemsPending.set(cacheKey, request);
+  try {
+    const data = await request;
+    cabinetItemsCache.set(cacheKey, { data, fetchedAt: Date.now() });
+    return data;
+  } finally {
+    cabinetItemsPending.delete(cacheKey);
+  }
+}
+
+export async function resolveCabinetMap(userId: string): Promise<Map<string, CabinetOption>> {
+  const options = await fetchCabinetOptions(userId);
+  const map = new Map<string, CabinetOption>();
+  options.forEach((option) => {
+    map.set(option.id, option);
+  });
+  return map;
+}
+
+export function buildItemListFromSummaries(
+  ids: string[],
+  summaries: Map<string, ItemSummary | null>
+): ItemSummary[] {
+  const results: ItemSummary[] = [];
+  const seen = new Set<string>();
+  for (const id of ids) {
+    if (typeof id !== "string" || id.trim().length === 0 || seen.has(id)) {
+      continue;
+    }
+    seen.add(id);
+    const summary = summaries.get(id);
+    if (summary) {
+      results.push(summary);
+    } else {
+      results.push({ id, title: "(找不到作品)", cabinetId: null, isMissing: true });
+    }
+  }
+  return results;
+}
+
+export function describeCabinet(
+  cabinetId: string | null,
+  cabinetMap: Map<string, CabinetOption>
+): { name: string; isLocked: boolean; missing: boolean } {
+  if (!cabinetId) {
+    return { name: "未指定", isLocked: false, missing: false };
+  }
+  const record = cabinetMap.get(cabinetId);
+  if (!record) {
+    return { name: "(找不到櫃子)", isLocked: false, missing: true };
+  }
+  const name = record.name || "未命名櫃子";
+  return { name, isLocked: record.isLocked, missing: false };
+}
+


### PR DESCRIPTION
## Summary
- add reusable helpers and UI for selecting related cabinets/items when editing notes
- persist and render note relation metadata across new/edit/detail/list flows with locked-item safeguards
- surface related notes on item detail pages and update Firestore validation for the new fields

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db4661472c832097798a8e89a00949