### PR TITLE
Fix Vercel build failure and improve note/item UI behavior

### DIFF
--- a/src/app/cabinets/page.tsx
+++ b/src/app/cabinets/page.tsx
@@ -86,7 +86,7 @@ export default function CabinetsPage() {
   const [favoritesOnly, setFavoritesOnly] = useState(false);
   const [displayMode, setDisplayMode] = useState<DisplayMode>("detailed");
   const [filtersExpanded, setFiltersExpanded] = useState(false);
-  const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
   const canChangeSortDirection = sortOption !== "custom";
   const directionButtonClass = (direction: SortDirection) =>
     `${buttonClass({
@@ -233,9 +233,7 @@ export default function CabinetsPage() {
       return filteredList;
     }
     const base = [...filteredList];
-    const directionFactor =
-      (sortDirection === "asc" ? 1 : -1) *
-      (sortOption === "recentUpdated" || sortOption === "itemCount" ? -1 : 1);
+    const directionFactor = sortDirection === "asc" ? 1 : -1;
     switch (sortOption) {
       case "recentUpdated":
         base.sort((a, b) => (a.updatedMs - b.updatedMs) * directionFactor);

--- a/src/app/item/[id]/page.tsx
+++ b/src/app/item/[id]/page.tsx
@@ -204,7 +204,7 @@ type AttributeDraftState = {
   nextUpdateAt: string;
 };
 
-type SectionKey = "progress" | "appearances" | "notes";
+type SectionKey = "progress" | "appearances" | "notes" | "relatedNotes";
 
 const defaultProgressType =
   (PROGRESS_TYPE_OPTIONS[0]?.value as ProgressType | undefined) ?? "chapter";
@@ -327,6 +327,7 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
     progress: true,
     appearances: false,
     notes: false,
+    relatedNotes: false,
   });
   const [appearanceExpanded, setAppearanceExpanded] =
     useState<Record<string, boolean>>({});
@@ -2931,47 +2932,65 @@ export default function ItemDetailPage({ params }: ItemPageProps) {
               <h2 className="text-xl font-semibold text-gray-900">相關筆記</h2>
               <p className="text-sm text-gray-500">檢視與此作品建立連結的筆記。</p>
             </div>
+            <div className="flex items-center gap-2 self-end sm:self-auto">
+              <button
+                type="button"
+                onClick={() => toggleSection("relatedNotes")}
+                className="h-9 rounded-lg border px-3 text-sm text-gray-600 transition hover:border-gray-300"
+                aria-expanded={sectionOpen.relatedNotes}
+                aria-controls="related-notes-content"
+              >
+                {sectionOpen.relatedNotes ? "收合" : "展開"}
+              </button>
+            </div>
           </div>
-          {relatedNotesLoading ? (
-            <p className="text-sm text-gray-500">載入中…</p>
-          ) : relatedNotesError ? (
+          {relatedNotesError ? (
             <div className="break-anywhere rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700">
               {relatedNotesError}
             </div>
-          ) : relatedNotes.length === 0 ? (
-            <p className="text-sm text-gray-500">目前尚未有相關筆記。</p>
-          ) : (
-            <ul className="space-y-3">
-              {relatedNotes.map((note) => {
-                const updatedText = note.updatedMs
-                  ? formatDateTime(Timestamp.fromMillis(note.updatedMs))
-                  : "—";
-                return (
-                  <li key={note.id}>
-                    <Link
-                      href={`/notes/${note.id}`}
-                      className="group flex items-start justify-between gap-3 rounded-2xl border bg-white/80 p-4 text-left shadow-sm transition hover:border-blue-200 hover:bg-blue-50/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
-                    >
-                      <div className="flex-1 space-y-2">
-                        <div className="flex items-start gap-2">
-                          <span className="break-anywhere text-base font-medium text-gray-900 group-hover:text-blue-700">
-                            {note.title}
-                          </span>
-                          {note.isFavorite ? (
-                            <span className="mt-1 text-xs text-amber-500" aria-label="最愛筆記">
-                              ★
+          ) : null}
+          <div
+            id="related-notes-content"
+            className={sectionOpen.relatedNotes ? "space-y-3" : "hidden"}
+            aria-hidden={!sectionOpen.relatedNotes}
+          >
+            {relatedNotesLoading ? (
+              <p className="text-sm text-gray-500">載入中…</p>
+            ) : relatedNotes.length === 0 ? (
+              <p className="text-sm text-gray-500">目前尚未有相關筆記。</p>
+            ) : (
+              <ul className="space-y-3">
+                {relatedNotes.map((note) => {
+                  const updatedText = note.updatedMs
+                    ? formatDateTime(Timestamp.fromMillis(note.updatedMs))
+                    : "—";
+                  return (
+                    <li key={note.id}>
+                      <Link
+                        href={`/notes/${note.id}`}
+                        className="group flex items-start justify-between gap-3 rounded-2xl border bg-white/80 p-4 text-left shadow-sm transition hover:border-blue-200 hover:bg-blue-50/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-200"
+                      >
+                        <div className="flex-1 space-y-2">
+                          <div className="flex items-start gap-2">
+                            <span className="break-anywhere text-base font-medium text-gray-900 group-hover:text-blue-700">
+                              {note.title}
                             </span>
-                          ) : null}
+                            {note.isFavorite ? (
+                              <span className="mt-1 text-xs text-amber-500" aria-label="最愛筆記">
+                                ★
+                              </span>
+                            ) : null}
+                          </div>
+                          <span className="text-xs text-gray-500">更新於：{updatedText}</span>
                         </div>
-                        <span className="text-xs text-gray-500">更新於：{updatedText}</span>
-                      </div>
-                      <span className="shrink-0 text-xs text-blue-600 group-hover:text-blue-700">檢視筆記</span>
-                    </Link>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
+                        <span className="shrink-0 text-xs text-blue-600 group-hover:text-blue-700">檢視筆記</span>
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
         </section>
       </div>
 

--- a/src/app/notes/[id]/page.tsx
+++ b/src/app/notes/[id]/page.tsx
@@ -610,8 +610,8 @@ export default function NoteDetailPage({ params }: PageProps) {
                   ✕
                 </button>
               </div>
-              <div className="flex flex-1 flex-col gap-4 px-6 py-5">
-                <div className="flex-1 overflow-hidden rounded-xl border border-gray-200">
+              <div className="flex flex-1 min-h-0 flex-col gap-4 px-6 py-5">
+                <div className="flex-1 min-h-0 overflow-hidden rounded-xl border border-gray-200">
                   <div className="h-full overflow-y-auto px-4 py-3">
                     <RichTextEditor
                       value={quickEditHtml}

--- a/src/lib/note-relations.ts
+++ b/src/lib/note-relations.ts
@@ -34,7 +34,7 @@ type ItemByIdCacheEntry = {
 const itemsByCabinetCache = new Map<string, ItemCacheEntry>();
 const pendingCabinetCache = new Map<string, Promise<NoteItemSummary[]>>();
 const itemsByIdCache = new Map<string, ItemByIdCacheEntry>();
-const pendingItemIdsCache = new Map<string, Promise<NoteItemSummary>>();
+const pendingItemIdsCache = new Map<string, Promise<NoteItemSummary | null>>();
 
 function now(): number {
   return Date.now();


### PR DESCRIPTION
## Summary
- allow cached item summary lookups to store null responses so type checking passes on Vercel
- ensure the notes quick edit dialog stays scrollable by constraining flex heights
- add collapse controls for the related notes panel and correct cabinet sorting defaults and direction handling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db89d713f48320bc3e0e9168d73449