### PR TITLE
Fix recent update sorting for cabinets and notes

### DIFF
--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -253,20 +253,28 @@ export default function NotesPage() {
 
   const sortedNotes = useMemo(() => {
     const base = [...filteredNotes];
-    const directionFactor = sortDirection === "asc" ? 1 : -1;
-    switch (sortOption) {
-      case "created":
-        base.sort((a, b) => (a.createdMs - b.createdMs) * directionFactor);
-        break;
-      case "title":
-        base.sort((a, b) =>
-          a.title.localeCompare(b.title, "zh-Hant", { sensitivity: "base" }) * directionFactor
-        );
-        break;
-      case "recentUpdated":
-      default:
-        base.sort((a, b) => (a.updatedMs - b.updatedMs) * directionFactor);
-        break;
+    const comparators: Record<
+      SortOption,
+      Record<SortDirection, (a: Note, b: Note) => number>
+    > = {
+      recentUpdated: {
+        asc: (a, b) => b.updatedMs - a.updatedMs,
+        desc: (a, b) => a.updatedMs - b.updatedMs,
+      },
+      created: {
+        asc: (a, b) => a.createdMs - b.createdMs,
+        desc: (a, b) => b.createdMs - a.createdMs,
+      },
+      title: {
+        asc: (a, b) =>
+          a.title.localeCompare(b.title, "zh-Hant", { sensitivity: "base" }),
+        desc: (a, b) =>
+          b.title.localeCompare(a.title, "zh-Hant", { sensitivity: "base" }),
+      },
+    };
+    const comparator = comparators[sortOption]?.[sortDirection];
+    if (comparator) {
+      base.sort(comparator);
     }
     return base;
   }, [filteredNotes, sortDirection, sortOption]);


### PR DESCRIPTION
## Summary
- derive the "recent update" cabinet ordering from the latest item update timestamps
- correct the notes page "recent update" sort option so the direction buttons behave as labeled

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db92ceea508320b68534e8681ac62c