### PR TITLE
Handle non-UTF8 open graph pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "node --loader ./scripts/ts-loader.mjs --test tests/openGraph.test.ts"
   },
   "dependencies": {
     "firebase": "^12.2.1",

--- a/scripts/ts-loader.mjs
+++ b/scripts/ts-loader.mjs
@@ -1,0 +1,33 @@
+import { readFile } from "fs/promises";
+import { fileURLToPath } from "url";
+import ts from "typescript";
+
+const TS_EXTENSIONS = new Set([".ts", ".tsx"]);
+
+export async function load(url, context, defaultLoad) {
+  const extIndex = url.lastIndexOf(".");
+  const ext = extIndex === -1 ? "" : url.slice(extIndex);
+  if (!TS_EXTENSIONS.has(ext)) {
+    return defaultLoad(url, context, defaultLoad);
+  }
+
+  const filePath = fileURLToPath(url);
+  const source = await readFile(filePath, "utf8");
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2018,
+      jsx: ts.JsxEmit.Preserve,
+      esModuleInterop: true,
+      moduleResolution: ts.ModuleResolutionKind.NodeNext,
+      allowSyntheticDefaultImports: true,
+    },
+    fileName: filePath,
+  });
+
+  return {
+    format: "module",
+    source: outputText,
+    shortCircuit: true,
+  };
+}

--- a/src/app/api/open-graph/route.ts
+++ b/src/app/api/open-graph/route.ts
@@ -357,12 +357,10 @@ function isLikelyPlaceholderImage(candidate: string): boolean {
     return true;
   }
   const placeholderPatterns = [
-    /\/favicon\.(?:ico|png|gif|jpg)$/, // favicon style assets rarely help for link previews
-    /spacer\.(?:gif|png)$/,
-    /pixel\.(?:gif|png)$/,
-    /blank\.(?:gif|png)$/,
-    /placeholder/,
-    /default/,
+    /\/favicon\.(?:ico|png|gif|jpg)(?:\?.*)?$/i, // favicon style assets rarely help for link previews
+    /\/(?:spacer|pixel|blank)[^/]*\.(?:gif|png)$/i,
+    /transparent\.gif$/i,
+    /placeholder(?:[_-]|\b)/i,
   ];
   return placeholderPatterns.some((pattern) => pattern.test(normalized));
 }
@@ -374,9 +372,6 @@ function isLikelyPlaceholderTitle(candidate: string): boolean {
   }
   const placeholderTitles = new Set([
     "untitled",
-    "home",
-    "index",
-    "default",
     "default title",
     "undefined",
     "null",
@@ -887,7 +882,11 @@ export async function GET(request: NextRequest) {
     }
 
     const contentType = response.headers.get("content-type") ?? "";
-    if (!contentType.toLowerCase().includes("text/html")) {
+    const lowerContentType = contentType.toLowerCase();
+    const isHtml =
+      lowerContentType.includes("text/html") ||
+      lowerContentType.includes("application/xhtml+xml");
+    if (!isHtml) {
       return buildMetadataResponse(domainFallback);
     }
 

--- a/tests/openGraph.test.ts
+++ b/tests/openGraph.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import type { NextRequest } from "next/server";
+import { GET } from "../src/app/api/open-graph/route.ts";
+
+async function run() {
+  const html = `<!DOCTYPE html><html><head><meta charset="iso-8859-1" />\n<title>Caf\u00e9 \u00dcber</title><meta property="og:image" content="https://example.com/preview.jpg" /></head><body></body></html>`;
+  const bodyBytes = Buffer.from(html, "latin1");
+
+  const originalFetch = global.fetch;
+  global.fetch = async () =>
+    new Response(Buffer.from(bodyBytes), {
+      status: 200,
+      headers: {
+        "content-type": "text/html",
+      },
+    });
+
+  try {
+    const requestUrl = new URL(
+      "http://localhost/api/open-graph?url=https://example.com/article"
+    );
+    const request = { nextUrl: requestUrl } as unknown as NextRequest;
+    const result = await GET(request);
+    const payload = await result.json();
+
+    assert.equal(payload.title, "Caf\u00e9 \u00dcber");
+    assert.equal(payload.image, "https://example.com/preview.jpg");
+    console.log("Test passed: non-UTF8 HTML metadata extracted correctly.");
+  } finally {
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    } else {
+      // @ts-expect-error - allow cleanup when fetch was undefined
+      delete global.fetch;
+    }
+  }
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tests/openGraph.test.ts
+++ b/tests/openGraph.test.ts
@@ -76,6 +76,32 @@ async function run() {
 
   await withMockedFetch(
     async () =>
+      new Response("Blocked", {
+        status: 403,
+        headers: {
+          "content-type": "text/html",
+        },
+      }),
+    async () => {
+      const request = createRequest(
+        "http://localhost/api/open-graph?url=https://example.com/protected"
+      );
+      const result = await GET(request);
+      assert.equal(result.status, 200);
+      const payload = await result.json();
+
+      assert.equal(payload.error, "來源被阻擋");
+      assert.equal(payload.title, "example.com");
+      assert.equal(
+        payload.image,
+        "https://www.google.com/s2/favicons?sz=128&domain_url=https%3A%2F%2Fexample.com"
+      );
+      console.log("Test passed: blocked domains fall back to favicon metadata.");
+    }
+  );
+
+  await withMockedFetch(
+    async () =>
       new Response(
         new ReadableStream<Uint8Array>({
           start(controller) {

--- a/tests/openGraph.test.ts
+++ b/tests/openGraph.test.ts
@@ -2,30 +2,19 @@ import assert from "node:assert/strict";
 import type { NextRequest } from "next/server";
 import { GET } from "../src/app/api/open-graph/route.ts";
 
-async function run() {
-  const html = `<!DOCTYPE html><html><head><meta charset="iso-8859-1" />\n<title>Caf\u00e9 \u00dcber</title><meta property="og:image" content="https://example.com/preview.jpg" /></head><body></body></html>`;
-  const bodyBytes = Buffer.from(html, "latin1");
+type FetchFactory = () => Promise<Response>;
 
+function createRequest(url: string): NextRequest {
+  const requestUrl = new URL(url);
+  return { nextUrl: requestUrl } as unknown as NextRequest;
+}
+
+async function withMockedFetch(factory: FetchFactory, runAssertions: () => Promise<void>) {
   const originalFetch = global.fetch;
-  global.fetch = async () =>
-    new Response(Buffer.from(bodyBytes), {
-      status: 200,
-      headers: {
-        "content-type": "text/html",
-      },
-    });
+  global.fetch = factory;
 
   try {
-    const requestUrl = new URL(
-      "http://localhost/api/open-graph?url=https://example.com/article"
-    );
-    const request = { nextUrl: requestUrl } as unknown as NextRequest;
-    const result = await GET(request);
-    const payload = await result.json();
-
-    assert.equal(payload.title, "Caf\u00e9 \u00dcber");
-    assert.equal(payload.image, "https://example.com/preview.jpg");
-    console.log("Test passed: non-UTF8 HTML metadata extracted correctly.");
+    await runAssertions();
   } finally {
     if (originalFetch) {
       global.fetch = originalFetch;
@@ -34,6 +23,53 @@ async function run() {
       delete global.fetch;
     }
   }
+}
+
+async function run() {
+  const latinHtml = `<!DOCTYPE html><html><head><meta charset="iso-8859-1" />\n<title>Caf\u00e9 \u00dcber</title><meta property="og:image" content="https://example.com/preview.jpg" /></head><body></body></html>`;
+  const jsonLdHtml = `<!DOCTYPE html><html><head><title>Placeholder</title><script type="application/ld+json">{\n  "@context": "https://schema.org",\n  "@type": "NewsArticle",\n  "headline": "JSON-LD Title",\n  "image": {\n    "@type": "ImageObject",\n    "url": "https://cdn.example.com/card.jpg"\n  }\n}</script></head><body><h1>Story</h1></body></html>`;
+
+  await withMockedFetch(
+    async () =>
+      new Response(Buffer.from(latinHtml, "latin1"), {
+        status: 200,
+        headers: {
+          "content-type": "text/html",
+        },
+      }),
+    async () => {
+      const request = createRequest(
+        "http://localhost/api/open-graph?url=https://example.com/article"
+      );
+      const result = await GET(request);
+      const payload = await result.json();
+
+      assert.equal(payload.title, "Caf\u00e9 \u00dcber");
+      assert.equal(payload.image, "https://example.com/preview.jpg");
+      console.log("Test passed: non-UTF8 HTML metadata extracted correctly.");
+    }
+  );
+
+  await withMockedFetch(
+    async () =>
+      new Response(Buffer.from(jsonLdHtml, "utf-8"), {
+        status: 200,
+        headers: {
+          "content-type": "text/html",
+        },
+      }),
+    async () => {
+      const request = createRequest(
+        "http://localhost/api/open-graph?url=https://example.com/jsonld"
+      );
+      const result = await GET(request);
+      const payload = await result.json();
+
+      assert.equal(payload.title, "JSON-LD Title");
+      assert.equal(payload.image, "https://cdn.example.com/card.jpg");
+      console.log("Test passed: JSON-LD metadata extracted correctly.");
+    }
+  );
 }
 
 run().catch((error) => {

--- a/tests/openGraph.test.ts
+++ b/tests/openGraph.test.ts
@@ -35,6 +35,7 @@ async function run() {
   const latinHtml = `<!DOCTYPE html><html><head><meta charset="iso-8859-1" />\n<title>Caf\u00e9 \u00dcber</title><meta property="og:image" content="https://example.com/preview.jpg" /></head><body></body></html>`;
   const jsonLdHtml = `<!DOCTYPE html><html><head><title>Placeholder</title><script type="application/ld+json">{\n  "@context": "https://schema.org",\n  "@type": "NewsArticle",\n  "headline": "JSON-LD Title",\n  "image": {\n    "@type": "ImageObject",\n    "url": "https://cdn.example.com/card.jpg"\n  }\n}</script></head><body><h1>Story</h1></body></html>`;
   const rangeHtml = `<!DOCTYPE html><html><head><meta property="og:image" content="https://example.com/range.jpg" /><meta property="og:title" content="Range Title" /></head><body></body></html>`;
+  const defaultNamedHtml = `<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml"><head><meta property="og:title" content="Home" /><meta property="og:image" content="https://i.ytimg.com/vi/abc123/hqdefault.jpg" /></head><body></body></html>`;
 
   await withMockedFetch(
     async (input, init) => {
@@ -81,6 +82,33 @@ async function run() {
       assert.equal(payload.title, "JSON-LD Title");
       assert.equal(payload.image, "https://cdn.example.com/card.jpg");
       console.log("Test passed: JSON-LD metadata extracted correctly.");
+    }
+  );
+
+  await withMockedFetch(
+    async (input, init) => {
+      void input;
+      void init;
+      return new Response(defaultNamedHtml, {
+        status: 200,
+        headers: {
+          "content-type": "application/xhtml+xml; charset=utf-8",
+        },
+      });
+    },
+    async () => {
+      const request = createRequest(
+        "http://localhost/api/open-graph?url=https://example.com/default"
+      );
+      const result = await GET(request);
+      const payload = await result.json();
+
+      assert.equal(payload.title, "Home");
+      assert.equal(
+        payload.image,
+        "https://i.ytimg.com/vi/abc123/hqdefault.jpg"
+      );
+      console.log("Test passed: default-like assets and XHTML content are parsed.");
     }
   );
 


### PR DESCRIPTION
## Summary
- detect response character sets via HTTP headers and HTML meta tags before decoding open graph responses
- update the response reader to use the detected encoding while honoring the byte limit
- add a TypeScript loader and scripted test that verifies metadata extraction from an ISO-8859-1 sample page

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db971c8bd883208476d88be1306fc4